### PR TITLE
Dockerfile: foreground and allow args to fuse-overlayfs

### DIFF
--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -17,5 +17,5 @@ RUN git clone https://github.com/containers/fuse-overlayfs && \
     LIBS="-ldl" LDFLAGS="-static" ./configure --prefix /usr && \
     make && \
     make install
-
-ENTRYPOINT ["/usr/bin/fuse-overlayfs"]
+USER 1000
+ENTRYPOINT ["/usr/bin/fuse-overlayfs","-f"]


### PR DESCRIPTION
building on #10 but now the args are passed through to the entrypoint.
I'm still not seeing that `-f` keeps it in the foreground though.