### PR TITLE
fuse-overlayfs: try alternative whiteout on ENOTSUP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - xz-utils
       - python3.5
       - g++
+      - python3-setuptools
 before_install:
   - sudo mkdir -p /lower /upper /mnt
   - (cd /; sudo git clone https://github.com/amir73il/unionmount-testsuite.git)

--- a/main.c
+++ b/main.c
@@ -383,7 +383,7 @@ create_whiteout (struct ovl_data *lo, struct ovl_node *parent, const char *name,
       if (ret == 0)
         return 0;
 
-      if (errno != EPERM)
+      if (errno != EPERM && errno != ENOTSUP)
         return -1;
 
       /* if it fails with EPERM then do not attempt mknod again.  */


### PR DESCRIPTION
if mknod fails with ENOTSUP then use the .wh.FILE variant.

Closes: https://github.com/containers/fuse-overlayfs/issues/17

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>