### PR TITLE
fuse-overlayfs: read correctly inode for dangling symlinks

### DIFF
--- a/main.c
+++ b/main.c
@@ -765,13 +765,18 @@ make_ovl_node (const char *path, struct ovl_layer *layer, const char *name, ino_
       for (it = layer; it; it = it->next)
         {
           ssize_t s;
-          int fd = TEMP_FAILURE_RETRY (openat (it->fd, path, O_RDONLY|O_NONBLOCK));
+          int fd = TEMP_FAILURE_RETRY (openat (it->fd, path, O_RDONLY|O_NONBLOCK|O_NOFOLLOW|O_PATH));
           if (fd < 0)
             continue;
 
           if (fstat (fd, &st) == 0)
             ret->ino = st.st_ino;
 
+          close (fd);
+
+          fd = TEMP_FAILURE_RETRY (openat (it->fd, path, O_RDONLY|O_NONBLOCK|O_NOFOLLOW));
+          if (fd < 0)
+            continue;
           s = fgetxattr (fd, PRIVILEGED_ORIGIN_XATTR, path, sizeof (path) - 1);
           if (s > 0)
             {

--- a/main.c
+++ b/main.c
@@ -2512,6 +2512,7 @@ ovl_setattr (fuse_req_t req, fuse_ino_t ino, struct stat *attr, int to_set, stru
       return;
     }
 
+  memset (times, 0, sizeof (times));
   times[0].tv_sec = UTIME_OMIT;
   times[1].tv_sec = UTIME_OMIT;
   if (to_set & FUSE_SET_ATTR_ATIME)


### PR DESCRIPTION
do not follow symlinks when stat'ing a path, so that we read the inode
of the symlink itself.

Closes: https://github.com/containers/fuse-overlayfs/issues/23

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>