### PR TITLE
copyup: fix error if lower file cannot be opened

### DIFF
--- a/main.c
+++ b/main.c
@@ -1857,11 +1857,11 @@ copyup (struct ovl_data *lo, struct ovl_node *node)
       goto success;
     }
 
-  sfd = TEMP_FAILURE_RETRY (openat (node_dirfd (node), node->path, O_RDONLY|O_NONBLOCK));
+  ret = sfd = TEMP_FAILURE_RETRY (openat (node_dirfd (node), node->path, O_RDONLY|O_NONBLOCK));
   if (sfd < 0)
     goto exit;
 
-  dfd = TEMP_FAILURE_RETRY (openat (lo->workdir_fd, wd_tmp_file_name, O_CREAT|O_WRONLY, st.st_mode));
+  ret = dfd = TEMP_FAILURE_RETRY (openat (lo->workdir_fd, wd_tmp_file_name, O_CREAT|O_WRONLY, st.st_mode));
   if (dfd < 0)
     goto exit;
 


### PR DESCRIPTION
propagate the error code to the caller if the lower file cannot be
opened.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>