### PR TITLE
fuse-overlayfs: use allow_other only when running with uid=0

### DIFF
--- a/main.c
+++ b/main.c
@@ -3589,7 +3589,7 @@ get_new_args (int *argc, char **argv)
   if (geteuid() == 0)
       newargv[1] = "-odefault_permissions,allow_other,suid";
   else
-      newargv[1] = "-odefault_permissions,allow_other";
+      newargv[1] = "-odefault_permissions";
   for (i = 1; i < *argc; i++)
     newargv[i + 1] = argv[i];
   (*argc)++;


### PR DESCRIPTION
Closes: https://github.com/containers/fuse-overlayfs/issues/35

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>