### PR TITLE
main: ignore EINVAL when copying xattrs

### DIFF
--- a/main.c
+++ b/main.c
@@ -1696,7 +1696,11 @@ copy_xattr (int sfd, int dfd, char *buf, size_t buf_size)
             return -1;
 
           if (fsetxattr (dfd, it, xattr_buf, s, 0) < 0)
-            return -1;
+            {
+              if (errno == EINVAL)
+                continue;
+              return -1;
+            }
         }
     }
   return 0;


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>