### PR TITLE
fuse-overlayfs: use autocleanup functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ before_install:
   - (git clone https://github.com/mesonbuild/meson.git; cd meson; sudo python3.5 ./setup.py install)
   - (wget https://github.com/libfuse/libfuse/releases/download/fuse-3.2.4/fuse-3.2.4.tar.xz; tar xf fuse-3.2.4.tar.xz; cd fuse-3.2.4; mkdir build; cd build; meson .. --prefix /usr && ninja && sudo ninja install)
 script:
-  - ./autogen.sh
-  - ./configure
-  - make -j $(nproc)
-  - sudo make -j install; sudo cp fuse-overlayfs /sbin
-  - (cd /unionmount-testsuite; sudo ./run --ov --fuse=fuse-overlayfs --xdev)
-  - (cd /unionmount-testsuite; FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT=1 sudo -E ./run --ov --fuse=fuse-overlayfs --xdev)
+  - ./autogen.sh || travis_terminate 1;
+  - ./configure || travis_terminate 1;
+  - make -j $(nproc) || travis_terminate 1;
+  - sudo make -j install; sudo cp fuse-overlayfs /sbin || travis_terminate 1;
+  - (cd /unionmount-testsuite; sudo ./run --ov --fuse=fuse-overlayfs --xdev) || travis_terminate 1;
+  - (cd /unionmount-testsuite; FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT=1 sudo -E ./run --ov --fuse=fuse-overlayfs --xdev) || travis_terminate 1;
   - sudo tests/fedora-installs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+services:
+  - docker
 language: c
 sudo: required
 dist: trusty
@@ -16,6 +18,7 @@ addons:
       - g++
       - python3-setuptools
 before_install:
+  - docker pull fedora &
   - sudo mkdir -p /lower /upper /mnt
   - (cd /; sudo git clone https://github.com/amir73il/unionmount-testsuite.git)
   - (git clone git://github.com/ninja-build/ninja.git && cd ninja && python3.5 ./bootstrap.py && sudo cp ninja /usr/bin)
@@ -28,3 +31,4 @@ script:
   - sudo make -j install; sudo cp fuse-overlayfs /sbin
   - (cd /unionmount-testsuite; sudo ./run --ov --fuse=fuse-overlayfs --xdev)
   - (cd /unionmount-testsuite; FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT=1 sudo -E ./run --ov --fuse=fuse-overlayfs --xdev)
+  - sudo tests/fedora-installs.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS = fuse-overlayfs
 
 ACLOCAL_AMFLAGS = -Im4
 
-EXTRA_DIST = m4/gnulib-cache.m4 rpm/fuse-overlayfs.spec.template autogen.sh fuse-overlayfs.1.md
+EXTRA_DIST = m4/gnulib-cache.m4 rpm/fuse-overlayfs.spec.template autogen.sh fuse-overlayfs.1.md utils.h
 
 CLEANFILES = fuse-overlayfs.1
 

--- a/main.c
+++ b/main.c
@@ -2331,13 +2331,6 @@ ovl_do_open (fuse_req_t req, fuse_ino_t parent, const char *name, int flags, mod
       if (p == NULL)
         return -1;
 
-      if (delete_whiteout (lo, -1, p, name) < 0)
-        return -1;
-
-      sprintf (path, "%s/%s", p->path, name);
-      if (unlinkat (get_upper_layer (lo)->fd, path, 0) < 0 && errno != ENOENT)
-        return -1;
-
       sprintf (wd_tmp_file_name, "%lu", get_next_wd_counter ());
 
       fd = TEMP_FAILURE_RETRY (openat (lo->workdir_fd, wd_tmp_file_name, flags, mode & ~ctx->umask));
@@ -2349,6 +2342,13 @@ ovl_do_open (fuse_req_t req, fuse_ino_t parent, const char *name, int flags, mod
           unlinkat (lo->workdir_fd, wd_tmp_file_name, 0);
           return -1;
         }
+
+      sprintf (path, "%s/%s", p->path, name);
+      if (unlinkat (get_upper_layer (lo)->fd, path, 0) < 0 && errno != ENOENT)
+        return -1;
+
+      if (delete_whiteout (lo, -1, p, name) < 0)
+        return -1;
 
       if (renameat (lo->workdir_fd, wd_tmp_file_name, get_upper_layer (lo)->fd, path) < 0)
         {

--- a/main.c
+++ b/main.c
@@ -3664,6 +3664,14 @@ fuse_opt_proc (void *data, const char *arg, int key, struct fuse_args *outargs)
     return 1;
   if (strcmp (arg, "dev") == 0)
     return 1;
+  if (strcmp (arg, "nosuid") == 0)
+    return 1;
+  if (strcmp (arg, "nodev") == 0)
+    return 1;
+  if (strcmp (arg, "exec") == 0)
+    return 1;
+  if (strcmp (arg, "noexec") == 0)
+    return 1;
 
   if (key == FUSE_OPT_KEY_NONOPT)
     {

--- a/main.c
+++ b/main.c
@@ -1277,6 +1277,9 @@ ovl_opendir (fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
   struct ovl_node *it;
   struct ovl_dirp *d = calloc (1, sizeof (struct ovl_dirp));
 
+  if (ovl_debug (req))
+    fprintf (stderr, "ovl_opendir(ino=%" PRIu64 ")\n", ino);
+
   if (d == NULL)
     {
       errno = ENOENT;
@@ -1493,6 +1496,8 @@ static void
 ovl_readdir (fuse_req_t req, fuse_ino_t ino, size_t size,
 	    off_t offset, struct fuse_file_info *fi)
 {
+  if (ovl_debug (req))
+    fprintf (stderr, "ovl_readdir(ino=%" PRIu64 ", size=%zu, offset=%llo)\n", ino, size, offset);
   ovl_do_readdir (req, ino, size, offset, fi, 0);
 }
 
@@ -1500,6 +1505,8 @@ static void
 ovl_readdirplus (fuse_req_t req, fuse_ino_t ino, size_t size,
 		off_t offset, struct fuse_file_info *fi)
 {
+  if (ovl_debug (req))
+    fprintf (stderr, "ovl_readdirplus(ino=%" PRIu64 ", size=%zu, offset=%llo)\n", ino, size, offset);
   ovl_do_readdir (req, ino, size, offset, fi, 1);
 }
 
@@ -1508,6 +1515,9 @@ ovl_releasedir (fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 {
   size_t s;
   struct ovl_dirp *d = ovl_dirp (fi);
+
+  if (ovl_debug (req))
+    fprintf (stderr, "ovl_releasedir(ino=%" PRIu64 ")\n", ino);
 
   for (s = 2; s < d->tbl_size; s++)
     {

--- a/main.c
+++ b/main.c
@@ -1010,6 +1010,7 @@ load_dir (struct ovl_data *lo, struct ovl_node *n, struct ovl_layer *layer, char
             if (insert_node (n, child, false) == NULL)
               {
                 errno = ENOMEM;
+                closedir (dp);
                 return NULL;
               }
         }
@@ -1799,7 +1800,10 @@ create_node_directory (struct ovl_data *lo, struct ovl_node *src)
 
   ret = TEMP_FAILURE_RETRY (fstat (sfd, &st));
   if (ret < 0)
-    return ret;
+    {
+      close (sfd);
+      return ret;
+    }
 
   times[0] = st.st_atim;
   times[1] = st.st_mtim;

--- a/main.c
+++ b/main.c
@@ -3516,6 +3516,8 @@ fuse_opt_proc (void *data, const char *arg, int key, struct fuse_args *outargs)
     return 1;
   if (strcmp (arg, "suid") == 0)
     return 1;
+  if (strcmp (arg, "dev") == 0)
+    return 1;
 
   if (key == FUSE_OPT_KEY_NONOPT)
     {

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+mkdir lower upper workdir merged
+
+fuse-overlayfs -o lowerdir=lower,upperdir=upper,workdir=workdir,suid,dev merged
+
+docker run --rm -ti -v merged:/merged fedora dnf --installroot /merged --releasever 29 install -y glibc-common
+
+umount merged
+
+# Make sure workdir is empty, and move the upper layer down
+rm -rf workdir lower
+mv upper lower
+mkdir upper workdir
+
+fuse-overlayfs -o lowerdir=lower,upperdir=upper,workdir=workdir,suid,dev merged
+
+# Install some big packages
+docker run --rm -ti -v merged:/merged fedora dnf --installroot /merged --releasever 29 install -y emacs texlive
+
+umount merged

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,57 @@
+/* fuse-overlayfs: Overlay Filesystem in Userspace
+
+   Copyright (C) 2019 Red Hat Inc.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef UTILS_H
+# define UTILS_H
+
+void
+cleanup_freep (void *p)
+{
+  void **pp = (void **) p;
+  free (*pp);
+}
+
+void
+cleanup_filep (FILE **f)
+{
+  FILE *file = *f;
+  if (file)
+    (void) fclose (file);
+}
+
+void
+cleanup_closep (void *p)
+{
+  int *pp = p;
+  if (*pp >= 0)
+    close (*pp);
+}
+
+void
+cleanup_dirp (DIR **p)
+{
+  DIR *dir = *p;
+  if (dir)
+    closedir (dir);
+}
+
+# define cleanup_file __attribute__((cleanup (cleanup_filep)))
+# define cleanup_free __attribute__((cleanup (cleanup_freep)))
+# define cleanup_close __attribute__((cleanup (cleanup_closep)))
+# define cleanup_dir __attribute__((cleanup (cleanup_dirp)))
+
+#endif


### PR DESCRIPTION
first pass at using `__attribute__((cleanup))`.  It helps to simplify a lot of code, and hopefully avoid some bugs.

We should ideally add custom cleanup functions for the structs we are defining.