### PR TITLE
fuse-overlays: fix interaction of unlink(2) with readdir(2)

### DIFF
--- a/main.c
+++ b/main.c
@@ -1486,7 +1486,7 @@ ovl_do_readdir (fuse_req_t req, fuse_ino_t ino, size_t size,
         const char *name;
         struct ovl_node *node = d->tbl[offset];
 
-        if (node == NULL || node->whiteout)
+        if (node == NULL || node->whiteout || node->hidden)
           continue;
 
         ret = rpl_stat (req, node, &st);


### PR DESCRIPTION
fix an interesting interaction between unlink(2) and readdir(2) that
can confuse the cache.

If a file is unlinked before the readdir(2) is done, it is not removed
from the list generated when the directory was first opened.  Thus the
result is that readdir(2) will return the file even if it was unlinked
and moved to the work dir until the cache is released.

The fix is to skip dentries that are hidden while iterating the list.

Closes: https://github.com/containers/libpod/issues/2342

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>