### PR TITLE
fuse-overlayfs: ignore xattrs copy errors when not supported

### DIFF
--- a/main.c
+++ b/main.c
@@ -1765,7 +1765,7 @@ copy_xattr (int sfd, int dfd, char *buf, size_t buf_size)
 
           if (fsetxattr (dfd, it, v, s, 0) < 0)
             {
-              if (errno == EINVAL)
+              if (errno == EINVAL || errno == EOPNOTSUPP)
                 continue;
               return -1;
             }


### PR DESCRIPTION
it solves this error on copy_xattrs when the underlying file system is
overlay:

flistxattr(9, "security.selinux\0", 1048576) = 17
fgetxattr(9, "security.selinux", "system_u:object_r:container_file"..., 256) = 48
fsetxattr(10, "security.selinux", "system_u:object_r:container_file"..., 48, 0) = -1

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>