### PR TITLE
README.md: update fuse version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ $ fuse-overlayfs -o uidmapping=0:10:100:100:10000:2000,gidmapping=0:10:100:100:1
 Build Requirements:
 =======================================================
 
-This links to libfuse > v3
+fuse-overlayfs requires libfuse > v3.2.1
 
-On fedora: `dnf install fuse3-devel`
+On Fedora: `dnf install fuse3-devel`
 
 
 Static Build:


### PR DESCRIPTION
we require FUSE 3.2.1, update the README to reflect it.

Closes: https://github.com/containers/fuse-overlayfs/issues/48

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>