### PR TITLE
fuse-overlayfs: fix first unlink done

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,4 @@ script:
   - (cd /unionmount-testsuite; sudo ./run --ov --fuse=fuse-overlayfs --xdev) || travis_terminate 1;
   - (cd /unionmount-testsuite; FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT=1 sudo -E ./run --ov --fuse=fuse-overlayfs --xdev) || travis_terminate 1;
   - sudo tests/fedora-installs.sh
+  - sudo tests/unlink.sh

--- a/tests/unlink.sh
+++ b/tests/unlink.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+mkdir lower upper workdir merged
+
+touch lower/a
+
+fuse-overlayfs -o lowerdir=lower,upperdir=upper,workdir=workdir,suid,dev merged
+
+unlink lower/a
+
+test \! -e lower/a
+
+umount merged


### PR DESCRIPTION
fix a regression introduced by f64f65287817fecd0 that prevents a
whiteout file to be created on the first unlink.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>