### PR TITLE
copyup: use sendfile(2) if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_PROG_CC
 gl_EARLY
 gl_INIT
 
-AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h stddef.h stdint.h stdlib.h string.h unistd.h])
+AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h stddef.h stdint.h stdlib.h string.h unistd.h sys/sendfile.h])
 
 AC_PROG_RANLIB
 


### PR DESCRIPTION
attempt to use sendfile(2) before falling back to a read/write loop.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>