### PR TITLE
ioctl: return immediately with not implemented ioctls

### DIFF
--- a/main.c
+++ b/main.c
@@ -3799,7 +3799,7 @@ ovl_ioctl (fuse_req_t req, fuse_ino_t ino, int cmd, void *arg,
 
     default:
         fuse_reply_err (req, ENOSYS);
-        break;
+        return;
     }
 
   if (fd < 0)


### PR DESCRIPTION
avoid to send an error response twice.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>