### PR TITLE
fuse-overlayfs: skip opaque whiteouts on unsupported filesystems (e.g…

### DIFF
--- a/main.c
+++ b/main.c
@@ -420,7 +420,7 @@ set_fd_opaque (int fd)
     {
       if (errno == ENOTSUP)
         return 0;
-      if (errno != EPERM || fsetxattr (fd, OPAQUE_XATTR, "y", 1, 0) < 0)
+      if (errno != EPERM || fsetxattr (fd, OPAQUE_XATTR, "y", 1, 0) < 0 && errno != ENOTSUP)
           return -1;
     }
 


### PR DESCRIPTION
Do not fail if xattr are not supported by the filesystem. This can happen for example if one uses a tmpfs as the upperdir.