### PR TITLE
fuse-overlayfs: do not copyup a whiteout on rename

### DIFF
--- a/main.c
+++ b/main.c
@@ -3343,7 +3343,7 @@ ovl_rename_direct (fuse_req_t req, fuse_ino_t parent, const char *name,
           destnode = NULL;
         }
 
-      if (destnode)
+      if (destnode && !destnode_is_whiteout)
         {
           /* If the node is still accessible then be sure we
              can write to it.  Fix it to be done when a write is

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -4,7 +4,7 @@ mkdir lower upper workdir merged
 
 fuse-overlayfs -o lowerdir=lower,upperdir=upper,workdir=workdir,suid,dev merged
 
-docker run --rm -ti -v merged:/merged fedora dnf --installroot /merged --releasever 29 install -y glibc-common
+docker run --rm -ti -v merged:/merged fedora dnf --installroot /merged --releasever 29 install -y glibc-common gedit
 
 umount merged
 
@@ -17,5 +17,7 @@ fuse-overlayfs -o lowerdir=lower,upperdir=upper,workdir=workdir,suid,dev merged
 
 # Install some big packages
 docker run --rm -ti -v merged:/merged fedora dnf --installroot /merged --releasever 29 install -y emacs texlive
+
+docker run --rm -ti -v merged:/merged fedora sh -c 'rm /usr/share/glib-2.0/schemas/gschemas.compiled; glib-compile-schemas /usr/share/glib-2.0/schemas/'
 
 umount merged


### PR DESCRIPTION
Closes: https://github.com/containers/fuse-overlayfs/issues/69

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>