### PR TITLE
Update static build instructions

### DIFF
--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,7 +1,7 @@
-FROM fedora:latest
+FROM docker.io/fedora:latest
 WORKDIR /build
 RUN dnf update -y && \
-    dnf install -y git make automake autoconf gcc glibc-static meson ninja-build
+    dnf install -y git make automake autoconf gcc glibc-static meson ninja-build clang
 
 RUN git clone https://github.com/libfuse/libfuse && \
     cd libfuse && \

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM docker.io/fedora:latest
+FROM registry.fedoraproject.org/fedora:latest
 WORKDIR /build
 RUN dnf update -y && \
     dnf install -y git make automake autoconf gcc glibc-static meson ninja-build clang

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ On Fedora: `dnf install fuse3-devel`
 Static Build:
 =======================================================
 
-`buildah bud -t ./Dockerfile.static .`
+`buildah bud -t fuse-overlayfs -f ./Dockerfile.static .`
 


### PR DESCRIPTION
There were three problems with the static build instructions:

1. `buildah` can't find an image without a search repository configured
1. I was getting a build error about missing compilers until I added clang
1. The readme had the `-t` and `-f` flags mixed up

With these changes, I was able to build with buildah `1.9.0-dev` :tada: 