### PR TITLE
Pin fedora image used for static build

### DIFF
--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:30
 WORKDIR /build
 RUN dnf update -y && \
     dnf install -y git make automake autoconf gcc glibc-static meson ninja-build


### PR DESCRIPTION
Latest as of today. Makes Dockerfile more reproducible
in the long run, helps pin down build failures more easily.

When investigating #73, I wasn't sure if the issue was
that `fedora:latest` has changed since last commit to
Dockerfile.static, or something else. Pinning the image
makes makes it easier to reason about 'did a source
change or did a base image change break this?'