### PR TITLE
main: skip ENOTDIR in a lookup

### DIFF
--- a/main.c
+++ b/main.c
@@ -1313,7 +1313,7 @@ do_lookup_file (struct ovl_data *lo, fuse_ino_t parent, const char *name)
             {
               int saved_errno = errno;
 
-              if (errno == ENOENT)
+              if (errno == ENOENT || errno == ENOTDIR)
                 {
                   if (node)
                     continue;
@@ -1323,7 +1323,7 @@ do_lookup_file (struct ovl_data *lo, fuse_ino_t parent, const char *name)
                     return NULL;
 
                   ret = TEMP_FAILURE_RETRY (fstatat (it->fd, whpath, &tmp_st, AT_SYMLINK_NOFOLLOW));
-                  if (ret < 0 && errno != ENOENT)
+                  if (ret < 0 && errno != ENOENT && errno != ENOTDIR)
                     return NULL;
                   if (ret == 0)
                     {


### PR DESCRIPTION
if we are looking for a path in a lower component, skip ENOTDIR as a
component might be a whiteout.

This happens only when running as root, as the whiteout takes the same
name of the deleted file/directory.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>