### PR TITLE
[WIP] fuse-overlayfs: add plugin system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,14 +4,14 @@ bin_PROGRAMS = fuse-overlayfs
 
 ACLOCAL_AMFLAGS = -Im4
 
-EXTRA_DIST = m4/gnulib-cache.m4 rpm/fuse-overlayfs.spec.template autogen.sh fuse-overlayfs.1.md utils.h NEWS
+EXTRA_DIST = m4/gnulib-cache.m4 rpm/fuse-overlayfs.spec.template autogen.sh fuse-overlayfs.1.md utils.h plugin.h NEWS
 
 CLEANFILES = fuse-overlayfs.1
 
 fuse_overlayfs_CFLAGS = -I . -I $(abs_srcdir)/lib $(FUSE_CFLAGS)
 fuse_overlayfs_LDFLAGS =
 fuse_overlayfs_LDADD = lib/libgnu.a $(FUSE_LIBS)
-fuse_overlayfs_SOURCES = main.c
+fuse_overlayfs_SOURCES = main.c plugin.c
 
 WD := $(shell pwd)
 

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,7 @@ LDFLAGS=$old_LDFLAGS
 
 AC_DEFINE_UNQUOTED([HAVE_FUSE_CACHE_READDIR], $cache_readdir, [Define if libfuse is available])
 
+AC_SEARCH_LIBS([dlopen], [dl], [], [AC_MSG_ERROR([unable to find dlopen()])])
 
 AC_FUNC_ERROR_AT_LINE
 AC_FUNC_MALLOC

--- a/plugin.c
+++ b/plugin.c
@@ -1,0 +1,105 @@
+/* fuse-overlayfs: Overlay Filesystem in Userspace
+
+   Copyright (C) 2019 Red Hat Inc.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <plugin.h>
+#include <stdlib.h>
+#include <error.h>
+#include <errno.h>
+#include <string.h>
+
+void
+plugin_load (struct ovl_plugin_context *context, const char *path)
+{
+  plugin_name name;
+  struct ovl_plugin *p;
+  plugin_version version;
+  void *handle = dlopen (path, RTLD_NOW|RTLD_LOCAL);
+  if (! handle)
+    error (EXIT_FAILURE, 0, "cannot load plugin %s: %s", path, dlerror());
+
+  p = calloc (1, sizeof (*p));
+  if (p == NULL)
+    error (EXIT_FAILURE, errno, "cannot load plugin %s", path);
+  p->next = context->plugins;
+
+  version = dlsym (handle, "plugin_version");
+  if (version == NULL)
+    error (EXIT_FAILURE, 0, "cannot find symbol `plugin_version` in plugin %s", path);
+
+  if (version () != 1)
+    error (EXIT_FAILURE, 0, "invalid plugin version for %s", path);
+
+  p->handle = handle;
+  name = dlsym (handle, "plugin_name");
+  if (name == NULL)
+    error (EXIT_FAILURE, 0, "cannot find symbol `plugin_name` in plugin %s", path);
+
+  p->name = name ();
+
+  if (plugin_find (context, p->name))
+    error (EXIT_FAILURE, 0, "plugin %s added twice", p->name);
+
+  p->init = dlsym (handle, "plugin_init");
+  if (p->init == NULL)
+    error (EXIT_FAILURE, 0, "cannot find symbol `plugin_init` in plugin %s", path);
+
+  p->fetch = dlsym (handle, "plugin_fetch");
+  if (p->fetch == NULL)
+    error (EXIT_FAILURE, 0, "cannot find symbol `plugin_fetch` in plugin %s", path);
+
+  p->release = dlsym (handle, "plugin_release");
+  if (p->release == NULL)
+    error (EXIT_FAILURE, 0, "cannot find symbol `plugin_release` in plugin %s", path);
+
+  context->plugins = p;
+}
+
+struct ovl_plugin *
+plugin_find (struct ovl_plugin_context *context, const char *name)
+{
+  struct ovl_plugin *it;
+
+  for (it = context->plugins; it; it = it->next)
+    {
+      if (strcmp (name, it->name) == 0)
+        return it;
+    }
+  return NULL;
+}
+
+int
+plugin_free (struct ovl_plugin_context *context)
+{
+  struct ovl_plugin *it, *next;
+
+  it = context->plugins;
+  while (it)
+    {
+      next = it->next;
+
+      dlclose (it->handle);
+      free (it);
+
+      it = next;
+    }
+
+  free (context);
+
+  return 0;
+}

--- a/plugin.h
+++ b/plugin.h
@@ -1,0 +1,58 @@
+/* fuse-overlayfs: Overlay Filesystem in Userspace
+
+   Copyright (C) 2019 Red Hat Inc.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PLUGIN_H
+# define PLUGIN_H
+# include <config.h>
+
+# include <dlfcn.h>
+
+enum
+  {
+   LAYER_MODE_METADATA  = 1 << 0,
+   LAYER_MODE_DIRECTORY = 1 << 1,
+   LAYER_MODE_FILE      = 1 << 2,
+  };
+
+typedef void *(*plugin_init)(const char *data, const char *workdir, int workdirfd, const char *target, int dirfd);
+typedef int (*plugin_fetch)(void *opaque, const char *parentdir, const char *path, int mode);
+typedef int (*plugin_release)(void *opaque);
+typedef const char *(*plugin_name)();
+typedef int (*plugin_version)();
+
+struct ovl_plugin
+{
+  struct ovl_plugin *next;
+  const char *name;
+  void *handle;
+
+  plugin_init init;
+  plugin_fetch fetch;
+  plugin_release release;
+};
+
+struct ovl_plugin_context
+{
+  struct ovl_plugin *plugins;
+};
+
+void plugin_load (struct ovl_plugin_context *context, const char *path);
+int plugin_free (struct ovl_plugin_context *context);
+struct ovl_plugin *plugin_find (struct ovl_plugin_context *context, const char *name);
+
+#endif


### PR DESCRIPTION
support loading layers on demand.

Add a simple plugin mechanism that will help to expand fuse-overlayfs
functionalities, in particular it allows to load data from a layer on
demand.

A plugin is loaded into fuse-overlayfs using the option:

-o plugins=path/to/plugin.so:path/to/another/plugin.so

A layer can use a plugin with the syntax:

-o lowerdir=//plugin-name/DATA-FOR-THE-PLUGIN/path

Each time a file/directory is looked up, if a plugin is registered for
a layer, the plugin is first notified about the request.

After the callback is invoked, fuse-overlayfs still expects the data
to be accessible at the specified directory.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>