### PR TITLE
main: fix compiler warning

### DIFF
--- a/main.c
+++ b/main.c
@@ -3767,8 +3767,8 @@ ovl_fsync (fuse_req_t req, fuse_ino_t ino, int datasync, struct fuse_file_info *
 }
 
 static void
-ovl_ioctl (fuse_req_t req, fuse_ino_t ino, int cmd, void *arg,
-           struct fuse_file_info *fi, unsigned flags,
+ovl_ioctl (fuse_req_t req, fuse_ino_t ino, unsigned int cmd, void *arg,
+           struct fuse_file_info *fi, unsigned int flags,
            const void *in_buf, size_t in_bufsz, size_t out_bufsz)
 {
   struct ovl_data *lo = ovl_data (req);


### PR DESCRIPTION
fix this warning:

main.c:3870:13: warning: initialization of ‘void (*)(struct fuse_req
 *, fuse_ino_t,  unsigned int,  void *, struct fuse_file_info *,
 unsigned int,  const void *, size_t,  size_t)’ {aka ‘void (*)(struct
 fuse_req *, long unsigned int,  unsigned int,  void *, struct
 fuse_file_info *, unsigned int,  const void *, long unsigned int,
 long unsigned int)’} from incompatible pointer type ‘void (*)(struct
 fuse_req *, fuse_ino_t,  long unsigned int,  void *, struct
 fuse_file_info *, unsigned int,  const void *, size_t,  size_t)’ {aka
 ‘void (*)(struct fuse_req *, long unsigned int,  long unsigned int,
 void *, struct fuse_file_info *, unsigned int,  const void *, long
 unsigned int,  long unsigned int)’} [-Wincompatible-pointer-types]

 3870 |    .ioctl = ovl_ioctl,
      |             ^~~~~~~~~

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>