### PR TITLE
main: fix type for flistxattr return

### DIFF
--- a/main.c
+++ b/main.c
@@ -2154,7 +2154,7 @@ ovl_access (fuse_req_t req, fuse_ino_t ino, int mask)
 static int
 copy_xattr (int sfd, int dfd, char *buf, size_t buf_size)
 {
-  size_t xattr_len;
+  ssize_t xattr_len;
 
   xattr_len = flistxattr (sfd, buf, buf_size);
   if (xattr_len > 0)


### PR DESCRIPTION
the return type is ssize_t, not size_t.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>