### PR TITLE
main: simplify setattr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [0.5], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [0.5.1], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
always use the /proc/self/fd/FD path when a fd is not available.

commit 0b0c7a3a01dae4de65ba79016a111d794c1d1719 introduced the regression.

Closes: https://github.com/containers/fuse-overlayfs/issues/99

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
