### PR TITLE
main: if the path is a dir, work on the proc path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ dist: xenial
 addons:
   apt:
     packages:
+      - attr
       - automake
       - autotools-dev
       - git

--- a/main.c
+++ b/main.c
@@ -2038,7 +2038,7 @@ ovl_listxattr (fuse_req_t req, fuse_ino_t ino, size_t size)
     }
 
   path[0] = '\0';
-  ret = open_fd_or_get_path (lo, node, path, &fd, O_WRONLY);
+  ret = open_fd_or_get_path (lo, node, path, &fd, O_RDONLY);
   if (ret < 0)
     {
       fuse_reply_err (req, errno);

--- a/main.c
+++ b/main.c
@@ -554,7 +554,7 @@ open_fd_or_get_path (struct ovl_data *lo, struct ovl_node *n, char *path, int *f
   path[0] = '\0';
 
   *fd = TEMP_FAILURE_RETRY (openat (node_dirfd (n), n->path, O_NONBLOCK|O_NOFOLLOW|mode));
-  if (*fd < 0 && errno == ELOOP)
+  if (*fd < 0 && (errno == ELOOP || errno == EISDIR))
     {
       get_node_path (lo, n, path);
       return 0;

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -45,5 +45,11 @@ fuse-overlayfs -o fast_ino_check=1,sync=0,lowerdir=lower,upperdir=upper,workdir=
 
 docker run --rm -ti -v $(pwd)/merged:/merged centos:6 yum --installroot /merged -y --releasever 6 install nano
 
+mkdir merged/a-directory
+
+setfattr -n user.foo -v bar merged/a-directory
+getfattr -d merged/a-directory | grep bar
+getfattr --only-values -n user.foo merged/a-directory | grep bar
+getfattr --only-values -n user.foo upper/a-directory | grep bar
 
 umount merged


### PR DESCRIPTION
when reading xattr, if the path cannot be open as it is a directory, operate on the /proc/fd/FD path.

Closes: https://github.com/containers/fuse-overlayfs/issues/104

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>
