### PR TITLE
main: introduce inodes cache

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS = fuse-overlayfs
 
 ACLOCAL_AMFLAGS = -Im4
 
-EXTRA_DIST = m4/gnulib-cache.m4 rpm/fuse-overlayfs.spec.template autogen.sh fuse-overlayfs.1.md utils.h
+EXTRA_DIST = m4/gnulib-cache.m4 rpm/fuse-overlayfs.spec.template autogen.sh fuse-overlayfs.1.md utils.h NEWS
 
 CLEANFILES = fuse-overlayfs.1
 

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,5 @@
+* fuse-overlayfs-0.6
+
+- fix an issue where changes to an inode would not be visible from another hard link.
+  The issue was always present but was made easier to reproduce with fuse-overlayfs 0.5
+  that enables FUSE writeback by default.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [0.5.2], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [0.6], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/tests/unlink.sh
+++ b/tests/unlink.sh
@@ -10,4 +10,13 @@ unlink merged/a
 
 test \! -e merged/a
 
+echo hello > merged/foo
+ln merged/foo merged/foo2
+rm merged/foo
+grep hello merged/foo2
+ln merged/foo2 merged/foo
+echo world >> merged/foo2
+grep hello merged/foo
+grep world merged/foo
+
 umount merged


### PR DESCRIPTION
introduce a hash map to refer from an inode to the file paths.
A recent change where we enable FUSE writeback by default uncovered an
underlying issue in fuse-overlayfs where changes to a file with
multiple links would not be visible from the other link.

For each inode, maintain a list of nodes that refer to it, so that we
can still access it when a link is removed and more importantly we can
use the inode value with FUSE.

Closes: https://github.com/containers/fuse-overlayfs/issues/108
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1744109

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>