### PR TITLE
correctly read inode for unix sockets

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+* fuse-overlayfs-0.6.1
+
+- fix a regression introduced with 0.6 where UNIX sockets could not be correctly created.
+
 * fuse-overlayfs-0.6
 
 - fix an issue where changes to an inode would not be visible from another hard link.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [0.6], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [0.6.1], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/main.c
+++ b/main.c
@@ -1348,8 +1348,7 @@ make_ovl_node (struct ovl_data *lo, const char *path, struct ovl_layer *layer, c
           cleanup_close int fd = TEMP_FAILURE_RETRY (openat (it->fd, npath, O_RDONLY|O_NONBLOCK|O_NOFOLLOW));
           if (fd < 0)
             {
-              /* It is a symlink, read only the ino.  */
-              if (errno == ELOOP && fstatat (it->fd, npath, &st, AT_SYMLINK_NOFOLLOW) == 0)
+              if (errno != EPERM && fstatat (it->fd, npath, &st, AT_SYMLINK_NOFOLLOW) == 0)
                 {
                   ret->tmp_ino = st.st_ino;
                   mode = st.st_mode;

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -47,6 +47,8 @@ docker run --rm -ti -v $(pwd)/merged:/merged centos:6 yum --installroot /merged 
 
 mkdir merged/a-directory
 
+python -c 'import socket; socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM).bind("merged/unix-socket")'
+
 setfattr -n user.foo -v bar merged/a-directory
 getfattr -d merged/a-directory | grep bar
 getfattr --only-values -n user.foo merged/a-directory | grep bar


### PR DESCRIPTION
read correctly the inode when processing a UNIX socket.
 
Regression introduced by b25bbde64dc5d06373e087d7fae6367acf1fd09e.

Closes: https://github.com/containers/fuse-overlayfs/issues/110

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>
