### PR TITLE
set_attrs: don't require write to S_IFREG

### DIFF
--- a/main.c
+++ b/main.c
@@ -3481,7 +3481,7 @@ ovl_setattr (fuse_req_t req, fuse_ino_t ino, struct stat *attr, int to_set, stru
       switch (mode & S_IFMT)
         {
         case S_IFREG:
-          cleaned_up_fd = fd = TEMP_FAILURE_RETRY (openat (dirfd, node->path, O_NOFOLLOW|O_NONBLOCK|O_WRONLY));
+          cleaned_up_fd = fd = TEMP_FAILURE_RETRY (openat (dirfd, node->path, O_NOFOLLOW|O_NONBLOCK|(to_set & FUSE_SET_ATTR_SIZE ? O_WRONLY : 0)));
           if (fd < 0)
             {
               fuse_reply_err (req, errno);


### PR DESCRIPTION
It's perfectly possible to set attributes by being the file's owner; one
does not need write access to the contents.

Alternative for: https://github.com/containers/fuse-overlayfs/pull/114

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>