### PR TITLE
main: store the new mode after chmod

### DIFF
--- a/main.c
+++ b/main.c
@@ -3560,6 +3560,7 @@ ovl_setattr (fuse_req_t req, fuse_ino_t ino, struct stat *attr, int to_set, stru
           fuse_reply_err (req, errno);
           return;
         }
+      node->ino->mode = attr->st_mode;
     }
 
   if (to_set & FUSE_SET_ATTR_SIZE)


### PR DESCRIPTION
after a successful chmod, store the new mode for the ino.

Closes: https://github.com/containers/fuse-overlayfs/issues/124

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>