### PR TITLE
main.c: reload the directory on stat

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+* fuse-overlayfs-0.6.5
+
+- stat reports correctly the number of links for a directory.
+
 * fuse-overlayfs-0.6.4
 
 - do not lose the setuid bit after a write when the writeback cache is used.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [0.6.4], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [0.6.5], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/main.c
+++ b/main.c
@@ -1862,6 +1862,16 @@ ovl_lookup (fuse_req_t req, fuse_ino_t parent, const char *name)
       return;
     }
 
+  if (node_dirp (node))
+    {
+      node = reload_dir (lo, node);
+      if (node == NULL)
+        {
+          fuse_reply_err (req, errno);
+          return;
+        }
+    }
+
   err = rpl_stat (req, node, -1, NULL, NULL, &e.attr);
   if (err)
     {
@@ -2108,6 +2118,16 @@ ovl_do_readdir (fuse_req_t req, fuse_ino_t ino, size_t size,
           }
         else
           {
+            if (node_dirp (node))
+              {
+                node = reload_dir (lo, node);
+                if (node == NULL)
+                  {
+                    fuse_reply_err (req, errno);
+                    return;
+                  }
+              }
+
             memset (&e, 0, sizeof (e));
             ret = rpl_stat (req, node, -1, NULL, NULL, st);
             if (ret < 0)

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -21,6 +21,11 @@ fuse-overlayfs -o sync=0,threaded=1,lowerdir=lower,upperdir=upper,workdir=workdi
 SUID_TEST=$(pwd)/suid-test
 (cd merged; $SUID_TEST)
 
+# Test the number of hard links for populated directories is > 2
+test $(stat -c %h merged/etc) -gt 2
+ls merged/usr
+test $(stat -c %h merged/usr) -gt 2
+
 stat -c %A upper/suid | grep s
 stat -c %a upper/nosuid | grep -v s
 


### PR DESCRIPTION
make sure the directory is reloaded so the correct number of links can
be retrieved.

Closes: https://github.com/containers/fuse-overlayfs/issues/131

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>