### PR TITLE
fuse-overlayfs: support running without upper layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,6 @@ fuse-overlayfs
 
 An implementation of overlay+shiftfs in FUSE for rootless containers.
 
-Limitations:
-=======================================================
-
-Read-only mode is not supported, so it is always required to specify
-an upperdir and a workingdir.
-
 Usage:
 =======================================================
 

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -67,3 +67,19 @@ getfattr --only-values -n user.foo merged/a-directory | grep bar
 getfattr --only-values -n user.foo upper/a-directory | grep bar
 
 umount merged
+
+touch lower/file-lower-layer
+
+# no upper layer
+fuse-overlayfs -o lowerdir=lower merged
+
+tar -c --to-stdout $(pwd)/merged > /dev/null
+
+set +o pipefail
+
+touch merged/a 2>&1 | grep Read-only
+touch merged/file-lower-layer 2>&1 | grep Read-only
+touch merged/usr 2>&1 | grep Read-only
+mkdir merged/abcd12345 2>&1 | grep Read-only
+ln merged/file-lower-layer merged/file-lower-layer-link 2>&1 | grep Read-only
+ln -s merged/file-lower-layer merged/a-symlink 2>&1 | grep Read-only


### PR DESCRIPTION
when there is no upper layer specified, fail every read operation with
EROFS.

Closes: https://github.com/containers/fuse-overlayfs/issues/100

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>