### PR TITLE
muslc: Fix build

### DIFF
--- a/plugin-manager.h
+++ b/plugin-manager.h
@@ -33,3 +33,13 @@ struct ovl_plugin *plugin_find (struct ovl_plugin_context *context, const char *
 struct ovl_plugin_context *load_plugins (const char *plugins);
 
 #endif
+
+/* taken from glibc unistd.h and fixes musl */
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(expression) \
+  (__extension__                                                              \
+    ({ long int __result;                                                     \
+       do __result = (long int) (expression);                                 \
+       while (__result == -1L && errno == EINTR);                             \
+       __result; }))
+#endif


### PR DESCRIPTION
Currently the build fails on muslc due to a missing definition (`TEMP_FAILURE_RETRY`) that's only available on glibc.

I've applied [this workaround](https://github.com/ostreedev/ostree/issues/731) and now the build succeeds .

```c
/* taken from glibc unistd.h and fixes musl */
#ifndef TEMP_FAILURE_RETRY
#define TEMP_FAILURE_RETRY(expression) \
  (__extension__                                                              \
    ({ long int __result;                                                     \
       do __result = (long int) (expression);                                 \
       while (__result == -1L && errno == EINTR);                             \
       __result; }))
#endif
```