### PR TITLE
main: prevent parent whiteout to hide file

### DIFF
--- a/main.c
+++ b/main.c
@@ -1432,7 +1432,7 @@ load_dir (struct ovl_data *lo, struct ovl_node *n, struct ovl_layer *layer, char
                 }
             }
 
-          strconcat3 (whiteout_path, PATH_MAX, ".wh.", dent->d_name, NULL);
+          strconcat3 (whiteout_path, PATH_MAX, path, "/.wh.", dent->d_name);
 
           strconcat3 (node_path, PATH_MAX, n->path, "/", dent->d_name);
 

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -127,3 +127,21 @@ fuse-overlayfs -o lowerdir=lower,upperdir=upper,workdir=workdir merged
 test \! -e merged/dir1/dir2/foo
 
 touch -h merged/deps.txt
+
+
+# https://github.com/containers/fuse-overlayfs/issues/151
+
+umount merged
+
+rm -rf lower upper workdir merged
+mkdir lower upper workdir merged
+mkdir lower/a lower/b
+touch lower/.wh.test lower/a/test lower/b/test
+
+fuse-overlayfs -o lowerdir=lower,upperdir=upper,workdir=workdir merged
+
+test -e merged/a/test
+
+ls -l merged/b
+
+test -e merged/b/test


### PR DESCRIPTION
use the full relative path when looking up the whiteout file,
otherwise a whiteout in the upper layer will hide files in
subdirectories.

Closes: https://github.com/containers/fuse-overlayfs/issues/151

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>