### PR TITLE
Fix build with -fno-common

### DIFF
--- a/fuse-overlayfs.h
+++ b/fuse-overlayfs.h
@@ -134,7 +134,7 @@ struct data_source
 };
 
 /* passtrough to the file system.  */
-struct data_source direct_access_ds;
+extern struct data_source direct_access_ds;
 
 # ifndef HAVE_STATX
 #  define STATX_TYPE		0x00000001U	/* Want/got stx_mode & S_IFMT */


### PR DESCRIPTION
To avoid that the compiler complains when building with `-fno-common`.
Can be reproduced by:

```
> make CFLAGS=-fno-common
...
ld: fuse_overlayfs-direct.o:(.data+0x0): multiple definition of \
    `direct_access_ds'; fuse_overlayfs-main.o:(.bss+0x0): \
    first defined here
ld: fuse_overlayfs-utils.o:(.bss+0x0): multiple definition of \
    `direct_access_ds'; fuse_overlayfs-main.o:(.bss+0x0): \
    first defined here
ld: fuse_overlayfs-plugin-manager.o:(.bss+0x0): multiple definition of \
    `direct_access_ds'; fuse_overlayfs-main.o:(.bss+0x0): \
    first defined here
```