### PR TITLE
Fix possible segmentation fault in direct_fsync()

### DIFF
--- a/main.c
+++ b/main.c
@@ -4595,6 +4595,12 @@ do_fsync (fuse_req_t req, fuse_ino_t ino, int datasync, int fd)
   /* Skip fsync for lower layers.  */
   do_fsync = node && node->layer == get_upper_layer (lo);
 
+  if (node->layer == NULL)
+    {
+      fuse_reply_err (req, ENOENT);
+      return;
+    }
+
   if (fd < 0)
     strcpy (path, node->path);
 


### PR DESCRIPTION
If the call to `get_upper_layer(lo)` returns `NULL` then the
`node->layer` will be `NULL`, too. If this is the case we pass `NULL` to
`direct_fsync()` which will cause a segmentation fault in:

```c
cfd = openat(l->fd, path, O_NOFOLLOW|O_DIRECTORY);
```

To fix this we now apply an additional check and error in the case of
`get_upper_layer(lo) == NULL`.
