### PR TITLE
main: force timeout 0 for ovl_link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - (wget https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz && tar xf go1.13.7.linux-amd64.tar.gz && sudo mv go /usr/local)
   - sudo mkdir -p /lower /upper /mnt
   - (cd /; sudo git clone https://github.com/amir73il/unionmount-testsuite.git)
-  - (git clone --depth 1 git://github.com/ninja-build/ninja.git && cd ninja && python3.5 ./bootstrap.py && sudo cp ninja /usr/bin)
+  - (git clone --depth 1 git://github.com/ninja-build/ninja.git && cd ninja && python3.5 configure.py --bootstrap && sudo cp ninja /usr/bin)
   - (git clone --depth 1 -b 0.51.1 https://github.com/mesonbuild/meson.git; cd meson; sudo python3.5 ./setup.py install)
   - (git clone --depth 1 https://github.com/sstephenson/bats.git; cd bats; sudo ./install.sh /usr/local)
   - ($GO get github.com/containers/storage; cd $GOPATH/src/github.com/containers/storage; sed -i -e 's|^AUTOTAGS.*$|AUTOTAGS := exclude_graphdriver_devicemapper exclude_graphdriver_btrfs|' Makefile; make GO=$GO containers-storage)

--- a/main.c
+++ b/main.c
@@ -3809,7 +3809,12 @@ ovl_link (fuse_req_t req, fuse_ino_t ino, fuse_ino_t newparent, const char *newn
 
   e.ino = node_to_inode (node);
   node->ino->lookups++;
-  e.attr_timeout = get_timeout (lo);
+  /*
+     There is an issue on RHEL 8.1 where the nlink counter is always
+     incremented by one, no matter what is specified in e.attr.st_nlink.
+     Always set timeout to 0 to force a new stat on the inode.
+   */
+  e.attr_timeout = 0;
   e.entry_timeout = get_timeout (lo);
   fuse_reply_entry (req, &e);
 }


### PR DESCRIPTION
There is an issue on RHEL 8.1 where the nlink counter is always
incremented by one, no matter what is specified in e.attr.st_nlink.

Always set timeout to 0 to force a new stat on the inode.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1802907
Closes: https://github.com/containers/fuse-overlayfs/issues/183

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>