### PR TITLE
main, rename: make sure destination is deleted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - (wget https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz && tar xf go1.13.7.linux-amd64.tar.gz && sudo mv go /usr/local)
   - sudo mkdir -p /lower /upper /mnt
   - (cd /; sudo git clone https://github.com/amir73il/unionmount-testsuite.git)
-  - (git clone --depth 1 git://github.com/ninja-build/ninja.git && cd ninja && python3.5 ./bootstrap.py && sudo cp ninja /usr/bin)
+  - (git clone --depth 1 git://github.com/ninja-build/ninja.git && cd ninja && python3.5 configure.py --bootstrap && sudo cp ninja /usr/bin)
   - (git clone --depth 1 -b 0.51.1 https://github.com/mesonbuild/meson.git; cd meson; sudo python3.5 ./setup.py install)
   - (git clone --depth 1 https://github.com/sstephenson/bats.git; cd bats; sudo ./install.sh /usr/local)
   - ($GO get github.com/containers/storage; cd $GOPATH/src/github.com/containers/storage; sed -i -e 's|^AUTOTAGS.*$|AUTOTAGS := exclude_graphdriver_devicemapper exclude_graphdriver_btrfs|' Makefile; make GO=$GO containers-storage)

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+* fuse-overlayfs-0.7.7
+
+- make sure the destination is deleted before doing a rename(2).  It prevents a left
+  over directory to cause delete to fail with EEXIST.
+- honor --debug.
+
 * fuse-overlayfs-0.7.6
 
 - do not look in lower layers for the ino if there is no origin xattr set.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [0.7.6], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [0.7.7], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/main.c
+++ b/main.c
@@ -2418,6 +2418,7 @@ create_directory (struct ovl_data *lo, int dirfd, const char *name, const struct
                   struct ovl_node *parent, int xattr_sfd, uid_t uid, gid_t gid, mode_t mode, bool set_opaque, struct stat *st_out)
 {
   int ret;
+  int saved_errno;
   cleanup_close int dfd = -1;
   cleanup_free char *buf = NULL;
   char wd_tmp_file_name[32];
@@ -2511,8 +2512,10 @@ create_directory (struct ovl_data *lo, int dirfd, const char *name, const struct
       ret = renameat (lo->workdir_fd, wd_tmp_file_name, dirfd, name);
     }
 out:
+  saved_errno = errno;
   if (ret < 0)
       unlinkat (lo->workdir_fd, wd_tmp_file_name, AT_REMOVEDIR);
+  errno = saved_errno;
 
   return ret;
 }

--- a/main.c
+++ b/main.c
@@ -4182,7 +4182,7 @@ ovl_rename_direct (fuse_req_t req, fuse_ino_t parent, const char *name,
               return;
             }
 
-          if (hide_node (lo, destnode, false) < 0)
+          if (hide_node (lo, destnode, true) < 0)
             goto error;
         }
     }


### PR DESCRIPTION
before doing a rename(2) make sure the destination is cleaned up,
otherwise a left-over directory can cause the rename to fail with
EEXIST.

Closes: https://github.com/containers/fuse-overlayfs/issues/189

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>