### PR TITLE
fuse-overlayfs: add missing definitions for _FILE_OFFSET_BITS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
       - libdevmapper-dev
       - btrfs-tools
       - go-md2man
+      - parallel
 before_install:
   - docker pull fedora &
   - docker build -t alpine-build -f Dockerfile.alpine .
@@ -31,8 +32,8 @@ before_install:
   - (cd /; sudo git clone https://github.com/amir73il/unionmount-testsuite.git)
   - (git clone --depth 1 git://github.com/ninja-build/ninja.git && cd ninja && python3.5 configure.py --bootstrap && sudo cp ninja /usr/bin)
   - (git clone --depth 1 -b 0.51.1 https://github.com/mesonbuild/meson.git; cd meson; sudo python3.5 ./setup.py install)
-  - (git clone --depth 1 https://github.com/sstephenson/bats.git; cd bats; sudo ./install.sh /usr/local)
-  - ($GO get github.com/containers/storage; cd $GOPATH/src/github.com/containers/storage; sed -i -e 's|^AUTOTAGS.*$|AUTOTAGS := exclude_graphdriver_devicemapper exclude_graphdriver_btrfs|' Makefile; make GO=$GO containers-storage)
+  - (git clone --depth 1 https://github.com/bats-core/bats-core; cd bats-core; sudo ./install.sh /usr/local)
+  - ($GO get github.com/containers/storage; cd $GOPATH/src/github.com/containers/storage; sed -i -e 's|^AUTOTAGS.*$|AUTOTAGS := exclude_graphdriver_devicemapper exclude_graphdriver_btrfs|' Makefile; make GO=$GO GO111MODULE=on containers-storage)
   - (wget https://github.com/libfuse/libfuse/releases/download/fuse-3.6.2/fuse-3.6.2.tar.xz; tar xf fuse-3.6.2.tar.xz; cd fuse-3.6.2; mkdir build; cd build; meson .. --prefix /usr && ninja && sudo ninja install)
 script:
   - ./autogen.sh || travis_terminate 1;

--- a/direct.c
+++ b/direct.c
@@ -19,6 +19,7 @@
 */
 
 #define _GNU_SOURCE
+#define _FILE_OFFSET_BITS 64
 
 #include <config.h>
 

--- a/plugin-manager.c
+++ b/plugin-manager.c
@@ -15,6 +15,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#define _GNU_SOURCE
+#define _FILE_OFFSET_BITS 64
 
 #include <config.h>
 #include <plugin.h>

--- a/utils.c
+++ b/utils.c
@@ -16,6 +16,9 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#define _GNU_SOURCE
+#define _FILE_OFFSET_BITS 64
+
 #include <config.h>
 #include "utils.h"
 #include <errno.h>


### PR DESCRIPTION
it caused an issue on armv7h where different versions of dirent struct
were used in main.c and in the other files.

Regression introduced with c2c2ac5b82fb59322da227d196214b4a58ede634

Closes: https://github.com/containers/fuse-overlayfs/issues/197

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>