### PR TITLE
main: correctly report copyup error

### DIFF
--- a/main.c
+++ b/main.c
@@ -2704,7 +2704,8 @@ copyup (struct ovl_data *lo, struct ovl_node *node)
   if (ret < 0)
     goto exit;
 
-  if (set_fd_origin (dfd, node->path) < 0)
+  ret = set_fd_origin (dfd, node->path);
+  if (ret < 0)
     goto exit;
 
   /* Finally, move the file to its destination.  */


### PR DESCRIPTION
the copyup function returns the error code set in ret.  Make sure ret
has the correct return code if set_fd_origin fails.

Closes: https://github.com/containers/fuse-overlayfs/issues/211

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>