### PR TITLE
mkdir: if the destination exists atomically swap them

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+* fuse-overlayfs-1.1.0
+
+- use openat(2) when available.
+- accept "ro" as mount option.
+- fix set mtime for a symlink.
+- fix some issues reported by static analysis.
+- fix potential infinite loop on a short read.
+- fix creating a directory if the destination already exists in the upper layer.
+
 * fuse-overlayfs-1.0.0
 
 - fix portability issue to 32 bits archs.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [1.0.0], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [1.1.0], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
if the destination already exists as it could not be properly cleaned
up, attempt to atomically swap the two directories and free the old
one.

Closes: https://github.com/containers/fuse-overlayfs/issues/213

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>