### PR TITLE
CI: Upload static release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,97 @@
+name: Release
+on:
+  push:
+    tags:
+    - 'test-cross-*'
+    - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: "Register QEMU to /proc/sys/fs/binfmt_misc"
+      run: docker run --rm --privileged linuxkit/binfmt:v0.8
+    - name: "Fetch buildx binary"
+      run: |
+        wget -O buildx https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64
+        chmod +x buildx
+    - name: "Initialize buildx"
+      run: |
+        ./buildx create --name cross --platform=amd64,arm,arm64,s390x,ppc64le  --use
+        ./buildx inspect --bootstrap
+    - name: "Build binaries from Dockerfile.cross"
+      run: ./buildx build -o /tmp --platform=amd64,arm64,arm,s390x,ppc64le -f Dockerfile.cross .
+    - name: "Create /tmp/artifact"
+      run: |
+        mkdir -p /tmp/artifact
+        mv /tmp/linux_amd64/fuse-overlayfs /tmp/artifact/fuse-overlayfs-x86_64
+        mv /tmp/linux_arm64/fuse-overlayfs /tmp/artifact/fuse-overlayfs-aarch64
+        mv /tmp/linux_arm_v7/fuse-overlayfs /tmp/artifact/fuse-overlayfs-armv7l
+        mv /tmp/linux_s390x/fuse-overlayfs /tmp/artifact/fuse-overlayfs-s390x
+        mv /tmp/linux_ppc64le/fuse-overlayfs /tmp/artifact/fuse-overlayfs-ppc64le
+    - name: "SHA256SUMS"
+      run: (cd /tmp/artifact; sha256sum *) | tee /tmp/SHA256SUMS
+    - name: "Create release"
+      uses: actions/create-release@v1
+      id: create_release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        draft: true
+    - name: "Upload fuse-overlayfs-x86_64"
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: /tmp/artifact/fuse-overlayfs-x86_64
+        asset_name: fuse-overlayfs-x86_64
+        asset_content_type: application/octet-stream
+    - name: "Upload fuse-overlayfs-aarch64"
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: /tmp/artifact/fuse-overlayfs-aarch64
+        asset_name: fuse-overlayfs-aarch64
+        asset_content_type: application/octet-stream
+    - name: "Upload fuse-overlayfs-armv7l"
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: /tmp/artifact/fuse-overlayfs-armv7l
+        asset_name: fuse-overlayfs-armv7l
+        asset_content_type: application/octet-stream
+    - name: "Upload fuse-overlayfs-s390x"
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: /tmp/artifact/fuse-overlayfs-s390x
+        asset_name: fuse-overlayfs-s390x
+        asset_content_type: application/octet-stream
+    - name: "Upload fuse-overlayfs-ppc64le"
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: /tmp/artifact/fuse-overlayfs-ppc64le
+        asset_name: fuse-overlayfs-ppc64le
+        asset_content_type: application/octet-stream
+    - name: "Upload SHA256SUMS"
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: /tmp/SHA256SUMS
+        asset_name: SHA256SUMS
+        asset_content_type: text/plain

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,0 +1,16 @@
+FROM --platform=$BUILDPLATFORM debian:10 AS fuse-overlayfs
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  git ca-certificates libc6-dev gcc make automake autoconf pkgconf libfuse3-dev file curl
+RUN curl -o /cross.sh https://raw.githubusercontent.com/tonistiigi/binfmt/18c3d40ae2e3485e4de5b453e8460d6872b24d6b/binfmt/scripts/cross.sh && chmod +x /cross.sh
+COPY . /fuse-overlayfs
+WORKDIR /fuse-overlayfs
+ARG TARGETPLATFORM
+RUN /cross.sh install gcc pkgconf libfuse3-dev | sh
+RUN ./autogen.sh && \
+  CC=$(/cross.sh cross-prefix)-gcc LD=$(/cross.sh cross-prefix)-ld LIBS="-ldl" LDFLAGS="-static" ./configure && \
+  make && mkdir /out && cp fuse-overlayfs /out && \
+  file /out/fuse-overlayfs | grep "statically linked"
+
+FROM scratch
+COPY --from=fuse-overlayfs /out/fuse-overlayfs /fuse-overlayfs


### PR DESCRIPTION
Fix #187 

Based on https://github.com/rootless-containers/slirp4netns/blob/99e1516d2b8c9187740082a0f975a87cd6a981b4/.github/workflows/release.yaml

Usage:
* Push `vX.Y.Z` tag to origin
* GitHub Action `release` automatically creates a draft release with binaries for x86_64, aarch64, armv7l, s390x, and ppc64le.
* Edit the draft and click the "Public release" button.

---

Logs: https://github.com/AkihiroSuda/fuse-overlayfs/runs/786829271 (Took 2m4s)
Artifacts: https://github.com/AkihiroSuda/fuse-overlayfs/releases/tag/test-cross-202006191303