### PR TITLE
main: fix lookup for overflow uid

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+* fuse-overlayfs-1.1.1
+
+- fix lookup for overflow uid when it is different than the overflow gid.
+
 * fuse-overlayfs-1.1.0
 
 - use openat2(2) when available.

--- a/main.c
+++ b/main.c
@@ -666,7 +666,7 @@ find_mapping (unsigned int id, struct ovl_mapping *mapping, bool direct, bool ui
 static uid_t
 get_uid (struct ovl_data *data, uid_t id)
 {
-  return find_mapping (id, data->uid_mappings, false, false);
+  return find_mapping (id, data->uid_mappings, false, true);
 }
 
 static uid_t

--- a/main.c
+++ b/main.c
@@ -5232,12 +5232,16 @@ main (int argc, char *argv[])
       mkdir (path, 0700);
       free (lo.workdir);
       lo.workdir = strdup (path);
+      if (lo.workdir == NULL)
+        error (EXIT_FAILURE, errno, "allocating workdir path");
 
       lo.workdir_fd = open (lo.workdir, O_DIRECTORY);
       if (lo.workdir_fd < 0)
         error (EXIT_FAILURE, errno, "cannot open workdir");
 
       dfd = dup (lo.workdir_fd);
+      if (dfd < 0)
+        error (EXIT_FAILURE, errno, "dup workdir file descriptor");
       empty_dirfd (dfd);
     }
 


### PR DESCRIPTION
we were mistakenly using the overflow GID also for UIDs lookups.  Not a big issue as they usually have the same value.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>