### PR TITLE
fuse-overlays: introduce xattr to override gid/uid/mode

### DIFF
--- a/contrib/fix-mode.py
+++ b/contrib/fix-mode.py
@@ -1,0 +1,51 @@
+#!/bin/python
+
+import os
+import sys
+import stat
+import errno
+
+XATTR_OVERRIDE_STAT_PRIVILEGED = "security.fuseoverlayfs.override_stat"
+XATTR_OVERRIDE_STAT = "user.fuseoverlayfs.override_stat"
+
+if os.geteuid() == 0:
+    xattr_name = XATTR_OVERRIDE_STAT_PRIVILEGED
+else:
+    xattr_name = XATTR_OVERRIDE_STAT
+
+cwd_fd = os.open(".", os.O_PATH)
+
+def fix_path(path):
+    st = os.lstat(path)
+    content = "%s:%s:%o" % (st.st_uid, st.st_gid,  stat.S_IMODE(st.st_mode))
+
+    try:
+        os.setxattr(path, xattr_name, str.encode(content), flags=os.XATTR_CREATE, follow_symlinks=False)
+    except Exception as e:
+        if e.errno == errno.EEXIST:
+            print("attr %s already present for %s: %s" % (XATTR_OVERRIDE_STAT, path, e.errno))
+            return
+        raise e
+
+    fd = os.open(path, os.O_PATH|os.O_NOFOLLOW|os.O_NONBLOCK)
+    try:
+        proc_path = "/proc/self/fd/%d" % fd
+        os.chmod(proc_path, 0o755)
+    except Exception as e:
+        if e.errno != errno.ENOTSUP:
+            raise e
+    finally:
+        os.close(fd)
+
+
+def fix_mode_directory(d):
+    for root, dirs, files in os.walk(d, topdown=False):
+        for i in dirs+files:
+            path = os.path.join(root, i)
+            fix_path(path)
+    fix_path(d)
+
+for i in sys.argv[1:]:
+    fix_mode_directory(i)
+
+        

--- a/fuse-overlayfs.h
+++ b/fuse-overlayfs.h
@@ -112,6 +112,8 @@ struct ovl_layer
   bool low;
 
   void *data_source_private_data;
+  unsigned int has_stat_override : 1;
+  unsigned int has_privileged_stat_override : 1;
 };
 
 /* a data_source defines the methods for accessing a lower layer.  */


### PR DESCRIPTION
introduce a new xattr "user.fuseoverlayfs.override_stat" that permit
to override the reported uid/gid/mode for lower layers.

It enables sharing storage among different users.

Since it is not possible to use "user.*" xattrs for symlinks, provide
also a privileged variant "security.fuseoverlayfs.override_stat", so
the root user can create the xattr for symlinks as well.

A script "fix-mode.py" is provided for converting an existing
layer/storage to the new model.  It is a destructive operation as
every file is converted to mode 0755, thus it is not usable anymore
with native overlay, or older versions of fuse-overlayfs.

Example with Podman:

Rootless:
Modify /.config/containers/storage.conf and add under storage.options:
additionalimagestores = ["/var/lib/shared-storage"]

Assuming an empty local storage for the user:

$ podman images
REPOSITORY                TAG     IMAGE ID      CREATED      SIZE    ReadOnly
docker.io/library/fedora  latest  a368cbcfa678  5 weeks ago  189 MB  true

and the files show the original mode and owner:

$ podman run --read-only --rm -ti docker.io/library/fedora ls -l /
lrwxrwxrwx.   1 root   root      7 Jan 28  2020 bin -> usr/bin
dr-xr-xr-x.   2 root   root      6 Jan 28  2020 boot
drwxr-xr-x.   5 root   root    360 Aug 15 13:26 dev
drwxr-xr-x.  41 root   root   4096 Jul  9 06:48 etc
drwxr-xr-x.   2 root   root      6 Jan 28  2020 home
lrwxrwxrwx.   1 root   root      7 Jan 28  2020 lib -> usr/lib
lrwxrwxrwx.   1 root   root      9 Jan 28  2020 lib64 -> usr/lib64
drwx------.   2 root   root      6 Jul  9 06:48 lost+found
drwxr-xr-x.   2 root   root      6 Jan 28  2020 media
drwxr-xr-x.   2 root   root      6 Jan 28  2020 mnt
drwxr-xr-x.   2 root   root      6 Jan 28  2020 opt
dr-xr-xr-x. 436 nobody nobody    0 Aug 15 13:26 proc
dr-xr-x---.   2 root   root    196 Jul  9 06:48 root
drwxrwxrwt.   3 root   root     80 Aug 15 13:26 run
lrwxrwxrwx.   1 root   root      8 Jan 28  2020 sbin -> usr/sbin
drwxr-xr-x.   2 root   root      6 Jan 28  2020 srv
dr-xr-xr-x.  13 nobody nobody    0 Aug  5 21:38 sys
drwxrwxrwt.   2 root   root     60 Aug 15 13:26 tmp
drwxr-xr-x.  12 root   root    144 Jul  9 06:48 usr
drwxr-xr-x.  18 root   root    235 Jul  9 06:48 var

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>