### PR TITLE
main: fix a potential leak and be more aggressive on releasing inodes

### DIFF
--- a/fuse-overlayfs.1
+++ b/fuse-overlayfs.1
@@ -55,7 +55,7 @@ reading/writing files to the system.
 
 .PP
 The fuse\-overlayfs dynamic mapping is an alternative and cheaper way
-to chown'ing the files on the host to accomodate the user namespace
+to chown'ing the files on the host to accommodate the user namespace
 settings.
 
 .PP

--- a/main.c
+++ b/main.c
@@ -168,6 +168,14 @@ static gid_t overflow_gid;
 
 static struct ovl_ino dummy_ino;
 
+struct stats_s
+{
+  size_t nodes;
+  size_t inodes;
+};
+
+static struct stats_s stats;
+
 static double
 get_timeout (struct ovl_data *lo)
 {
@@ -905,6 +913,7 @@ node_free (void *p)
   if (n->do_rmdir)
     unlinkat (n->hidden_dirfd, n->path, AT_REMOVEDIR);
 
+  stats.nodes--;
   free (n->name);
   free (n->path);
   free (n);
@@ -926,6 +935,7 @@ inode_free (void *p)
       node_free (tmp);
   }
 
+  stats.inodes--;
   free (i);
 }
 
@@ -1143,6 +1153,7 @@ register_inode (struct ovl_data *lo, struct ovl_node *n, mode_t mode)
       return NULL;
     }
 
+  stats.inodes++;
   return ino->node;
 }
 
@@ -1248,6 +1259,7 @@ make_whiteout_node (const char *path, const char *name)
   ret_xchg = ret;
   ret = NULL;
 
+  stats.nodes++;
   return ret_xchg;
 }
 
@@ -1460,6 +1472,7 @@ no_fd:
   ret_xchg = ret;
   ret = NULL;
 
+  stats.nodes++;
   return register_inode (lo, ret_xchg, mode);
 }
 

--- a/main.c
+++ b/main.c
@@ -951,6 +951,13 @@ drop_node_from_ino (Hash_table *inodes, struct ovl_node *node)
 
   ino = node->ino;
 
+  if (ino->lookups == 0)
+    {
+      hash_delete (inodes, ino);
+      inode_free (ino);
+      return;
+    }
+
   /* If it is the only node referenced by the inode, do not destroy it.  */
   if (ino->node == node && node->next_link == NULL)
     return;


### PR DESCRIPTION
if the reference held by the directory is the last one, it would miss to clean up the inode.  Fix it by calling do_forget.

Closes: https://github.com/containers/fuse-overlayfs/issues/238

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>