### PR TITLE
man: removing the duplicate description of workdir option

### DIFF
--- a/fuse-overlayfs.1
+++ b/fuse-overlayfs.1
@@ -43,11 +43,6 @@ A directory used internally by fuse\-overlays, must be on the same file
 system as the upper dir.
 
 .PP
-\fB\-o workdir=workdir\fP
-A directory used internally by fuse\-overlays, must be on the same file
-system as the upper dir.
-
-.PP
 \fB\-o uidmapping=UID:MAPPED\-UID:LEN[,UID2:MAPPED\-UID2:LEN2]\fP
 \fB\-o gidmapping=GID:MAPPED\-GID:LEN[,GID2:MAPPED\-GID2:LEN2]\fP
 Specifies the dynamic UID/GID mapping used by fuse\-overlayfs when


### PR DESCRIPTION
Signed-off-by: Vasily Tarasov <vtarasov@us.ibm.com>