### PR TITLE
main: always remap ids when specified

### DIFF
--- a/direct.c
+++ b/direct.c
@@ -213,12 +213,6 @@ direct_num_of_layers (const char *opaque, const char *path)
   return 1;
 }
 
-static bool
-direct_must_be_remapped (struct ovl_layer *l)
-{
-  return l->has_privileged_stat_override == 0 && l->has_stat_override == 0;
-}
-
 struct data_source direct_access_ds =
   {
    .num_of_layers = direct_num_of_layers,
@@ -234,5 +228,4 @@ struct data_source direct_access_ds =
    .getxattr = direct_getxattr,
    .listxattr = direct_listxattr,
    .readlinkat = direct_readlinkat,
-   .must_be_remapped = direct_must_be_remapped,
   };

--- a/fuse-overlayfs.h
+++ b/fuse-overlayfs.h
@@ -134,7 +134,6 @@ struct data_source
   int (*listxattr)(struct ovl_layer *l, const char *path, char *buf, size_t size);
   int (*getxattr)(struct ovl_layer *l, const char *path, const char *name, char *buf, size_t size);
   ssize_t (*readlinkat)(struct ovl_layer *l, const char *path, char *buf, size_t bufsiz);
-  bool (*must_be_remapped)(struct ovl_layer *l);
 };
 
 /* passthrough to the file system.  */

--- a/main.c
+++ b/main.c
@@ -865,11 +865,8 @@ rpl_stat (fuse_req_t req, struct ovl_node *node, int fd, const char *path, struc
   if (ret < 0)
     return ret;
 
-  if (l->ds->must_be_remapped && l->ds->must_be_remapped (l))
-    {
-      st->st_uid = find_mapping (st->st_uid, data, true, true);
-      st->st_gid = find_mapping (st->st_gid, data, true, false);
-    }
+  st->st_uid = find_mapping (st->st_uid, data, true, true);
+  st->st_gid = find_mapping (st->st_gid, data, true, false);
 
   st->st_ino = node->tmp_ino;
   st->st_dev = node->tmp_dev;


### PR DESCRIPTION
if a mapping is specified, make sure it is always honored, also when
using xattr permissions.

Closes: https://github.com/containers/fuse-overlayfs/issues/253

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>