### PR TITLE
main: open hidden files

### DIFF
--- a/main.c
+++ b/main.c
@@ -3467,7 +3467,10 @@ ovl_do_open (fuse_req_t req, fuse_ino_t parent, const char *name, int flags, mod
   n = do_lookup_file (lo, parent, name);
   if (n && n->hidden)
     {
-      n = NULL;
+      if (retnode)
+        *retnode = n;
+
+      return openat (n->hidden_dirfd, n->path, flags, mode);
     }
   if (n && !n->whiteout && (flags & O_CREAT))
     {

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -199,3 +199,10 @@ if touch merged/$(printf %${upper_max_filename_len}s | tr ' ' A}); then
 fi
 
 touch merged/$(printf %${merged_max_filename_len}s | tr ' ' A})
+
+# If a file is removed but referenced, we must still be able to access it.
+echo 12345 > merged/toremove
+sleep 30 < merged/toremove &
+sleep_pid=$!
+rm merged/toremove
+grep 12345 /proc/$sleep_pid/fd/0


### PR DESCRIPTION
if a file is delete and not accessible from the file system, but it is
still referenced, we must be able to open and use it.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>