### PR TITLE
main: honor user.containers.override_stat

### DIFF
--- a/direct.c
+++ b/direct.c
@@ -194,9 +194,9 @@ direct_load_data_source (struct ovl_layer *l, const char *opaque, const char *pa
     }
 
   if (fgetxattr (l->fd, XATTR_PRIVILEGED_OVERRIDE_STAT, tmp, sizeof (tmp)) >= 0)
-    l->has_privileged_stat_override = 1;
+    l->stat_override_mode = STAT_OVERRIDE_PRIVILEGED;
   else if (fgetxattr (l->fd, XATTR_OVERRIDE_STAT, tmp, sizeof (tmp)) >= 0)
-    l->has_stat_override = 1;
+    l->stat_override_mode = STAT_OVERRIDE_USER;
 
   return 0;
 }

--- a/direct.c
+++ b/direct.c
@@ -197,6 +197,8 @@ direct_load_data_source (struct ovl_layer *l, const char *opaque, const char *pa
     l->stat_override_mode = STAT_OVERRIDE_PRIVILEGED;
   else if (fgetxattr (l->fd, XATTR_OVERRIDE_STAT, tmp, sizeof (tmp)) >= 0)
     l->stat_override_mode = STAT_OVERRIDE_USER;
+  else if (fgetxattr (l->fd, XATTR_OVERRIDE_CONTAINERS_STAT, tmp, sizeof (tmp)) >= 0)
+    l->stat_override_mode = STAT_OVERRIDE_CONTAINERS;
 
   return 0;
 }

--- a/fuse-overlayfs.h
+++ b/fuse-overlayfs.h
@@ -109,6 +109,7 @@ enum stat_override_mode
   STAT_OVERRIDE_NONE,
   STAT_OVERRIDE_USER,
   STAT_OVERRIDE_PRIVILEGED,
+  STAT_OVERRIDE_CONTAINERS,
 };
 
 struct ovl_layer

--- a/fuse-overlayfs.h
+++ b/fuse-overlayfs.h
@@ -104,6 +104,13 @@ struct ovl_data
   struct ovl_plugin_context *plugins_ctx;
 };
 
+enum stat_override_mode
+{
+  STAT_OVERRIDE_NONE,
+  STAT_OVERRIDE_USER,
+  STAT_OVERRIDE_PRIVILEGED,
+};
+
 struct ovl_layer
 {
   struct ovl_layer *next;
@@ -114,8 +121,7 @@ struct ovl_layer
   bool low;
 
   void *data_source_private_data;
-  unsigned int has_stat_override : 1;
-  unsigned int has_privileged_stat_override : 1;
+  int stat_override_mode;
 };
 
 /* a data_source defines the methods for accessing a lower layer.  */

--- a/utils.c
+++ b/utils.c
@@ -240,10 +240,23 @@ override_mode (struct ovl_layer *l, int fd, const char *abs_path, const char *pa
   cleanup_close int cleanup_fd = -1;
   const char *xattr_name;
 
-  if (l->has_stat_override == 0 && l->has_privileged_stat_override == 0)
-    return 0;
+  switch (l->stat_override_mode)
+    {
+    case STAT_OVERRIDE_NONE:
+      return 0;
 
-  xattr_name = l->has_privileged_stat_override ? XATTR_PRIVILEGED_OVERRIDE_STAT : XATTR_OVERRIDE_STAT;
+    case STAT_OVERRIDE_USER:
+      xattr_name = XATTR_OVERRIDE_STAT;
+      break;
+
+    case STAT_OVERRIDE_PRIVILEGED:
+      xattr_name = XATTR_PRIVILEGED_OVERRIDE_STAT;
+      break;
+
+    default:
+      errno = EINVAL;
+      return -1;
+    }
 
   if (fd >= 0)
     {

--- a/utils.c
+++ b/utils.c
@@ -253,6 +253,10 @@ override_mode (struct ovl_layer *l, int fd, const char *abs_path, const char *pa
       xattr_name = XATTR_PRIVILEGED_OVERRIDE_STAT;
       break;
 
+    case STAT_OVERRIDE_CONTAINERS:
+      xattr_name = XATTR_OVERRIDE_CONTAINERS_STAT;
+      break;
+
     default:
       errno = EINVAL;
       return -1;

--- a/utils.h
+++ b/utils.h
@@ -33,6 +33,7 @@
 
 # define XATTR_OVERRIDE_STAT "user.fuseoverlayfs.override_stat"
 # define XATTR_PRIVILEGED_OVERRIDE_STAT "security.fuseoverlayfs.override_stat"
+# define XATTR_OVERRIDE_CONTAINERS_STAT "user.containers.override_stat"
 
 void cleanup_freep (void *p);
 void cleanup_filep (FILE **f);


### PR DESCRIPTION
also honor user.containers.override_stat to override containers stat override as it is set by containers/storage.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>