### PR TITLE
main: invalidate directory cache on create/rename

### DIFF
--- a/fuse-overlayfs.h
+++ b/fuse-overlayfs.h
@@ -50,6 +50,7 @@ struct ovl_node
   Hash_table *inodes;
   struct ovl_ino *ino;
   struct ovl_node *next_link;
+  unsigned int in_readdir;
 
   unsigned int do_unlink : 1;
   unsigned int do_rmdir : 1;


### PR DESCRIPTION
if we are adding a new file to a directory, the parent directory must
be invalidated if it is in the middle of a opendir/releasedir
otherwise the added files won't be cached.

Closes: https://github.com/containers/fuse-overlayfs/issues/259

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>