### PR TITLE
fuse-overlayfs: fix renameat2(RENAME_NOREPLACE)

### DIFF
--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -206,3 +206,8 @@ sleep 30 < merged/toremove &
 sleep_pid=$!
 rm merged/toremove
 grep 12345 /proc/$sleep_pid/fd/0
+
+RUN touch merged/a merged/b
+RUN chmod 6 merged/a
+RUN mv merged/a merged/x
+RUN mv merged/b merged/a


### PR DESCRIPTION
when device whiteouts are created (supported for unprivileged users in
newer Linux kernels) make sure the RENAME_NOREPLACE flag is dropped
when renaming the file on top of an existing whiteout.

Closes: https://github.com/containers/fuse-overlayfs/issues/273

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>