### PR TITLE
main: Add option static_nlink to set st_nlink to 1 for all directories

### DIFF
--- a/fuse-overlayfs.1
+++ b/fuse-overlayfs.1
@@ -116,6 +116,16 @@ Every file and directory is owned by the specified uid or gid.
 .PP
 It has higher precedence over \fBsquash\_to\_root\fP\&.
 
+.PP
+\fB\-o static\_nlink\fP
+Set st\_nlink to the static value 1 for all directories.
+
+.PP
+This can be useful for higher latency file systems such as NFS, where
+counting the number of hard links for a directory with many files can
+be a slow operation. With this option enabled, the number of hard
+links reported when running stat for any directory is 1.
+
 
 .SH SEE ALSO
 .PP

--- a/fuse-overlayfs.1.md
+++ b/fuse-overlayfs.1.md
@@ -93,6 +93,14 @@ Every file and directory is owned by the specified uid or gid.
 
 It has higher precedence over **squash_to_root**.
 
+**-o static_nlink**
+Set st_nlink to the static value 1 for all directories.
+
+This can be useful for higher latency file systems such as NFS, where
+counting the number of hard links for a directory with many files can
+be a slow operation. With this option enabled, the number of hard
+links reported when running stat for any directory is 1.
+
 # SEE ALSO
 
 **fuse**(8), **mount**(8), **user_namespaces**(7)

--- a/fuse-overlayfs.h
+++ b/fuse-overlayfs.h
@@ -99,6 +99,7 @@ struct ovl_data
   int squash_to_root;
   int squash_to_uid;
   int squash_to_gid;
+  int static_nlink;
 
   /* current uid/gid*/
   uid_t uid;


### PR DESCRIPTION
This is a continuation of the discussion in #193 and solves #182.

We've been using (something like) this internally for almost a year, and for our limited use case it works fine.

Anything that relies on accurate values for st_nlink will obviously break if this option is enabled.