### PR TITLE
main: fix reading xattrs longer than 256 bytes

### DIFF
--- a/main.c
+++ b/main.c
@@ -1373,9 +1373,10 @@ safe_read_xattr (char **ret, int sfd, const char *name, size_t initial_size)
       char *tmp;
 
       s = fgetxattr (sfd, name, buffer, current_size);
-      if (s < 0)
+      if (s >= 0 && s < current_size)
         break;
-      if (s < current_size)
+
+      if (s < 0 && errno != ERANGE)
         break;
 
       current_size *= 2;

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -70,6 +70,9 @@ umount merged
 
 touch lower/file-lower-layer
 
+# set a "big" xattr
+setfattr -n user.big-xattr -v "$(seq 1000 | tr -d '\n')" lower/file-lower-layer
+
 # no upper layer
 fuse-overlayfs -o lowerdir=lower merged
 


### PR DESCRIPTION
fix reading extended attributes longer than 256 bytes.

Closes: https://github.com/containers/fuse-overlayfs/issues/284

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>