### PR TITLE
Fix flaws in utimensat() handling

### DIFF
--- a/main.c
+++ b/main.c
@@ -3947,19 +3947,19 @@ ovl_setattr (fuse_req_t req, fuse_ino_t ino, struct stat *attr, int to_set, stru
   l = release_big_lock ();
 
   memset (times, 0, sizeof (times));
-  times[0].tv_sec = UTIME_OMIT;
-  times[1].tv_sec = UTIME_OMIT;
+  times[0].tv_nsec = UTIME_OMIT;
+  times[1].tv_nsec = UTIME_OMIT;
   if (to_set & FUSE_SET_ATTR_ATIME)
     times[0] = attr->st_atim;
   else if (to_set & FUSE_SET_ATTR_ATIME_NOW)
-    times[0].tv_sec = UTIME_NOW;
+    times[0].tv_nsec = UTIME_NOW;
 
   if (to_set & FUSE_SET_ATTR_MTIME)
     times[1] = attr->st_mtim;
   else if (to_set & FUSE_SET_ATTR_MTIME_NOW)
-    times[1].tv_sec = UTIME_NOW;
+    times[1].tv_nsec = UTIME_NOW;
 
-  if (times[0].tv_sec != UTIME_OMIT || times[1].tv_sec != UTIME_OMIT)
+  if (times[0].tv_nsec != UTIME_OMIT || times[1].tv_nsec != UTIME_OMIT)
     {
       if (fd >= 0)
         ret = futimens (fd, times);

--- a/main.c
+++ b/main.c
@@ -3950,14 +3950,18 @@ ovl_setattr (fuse_req_t req, fuse_ino_t ino, struct stat *attr, int to_set, stru
   times[0].tv_nsec = UTIME_OMIT;
   times[1].tv_nsec = UTIME_OMIT;
   if (to_set & FUSE_SET_ATTR_ATIME)
-    times[0] = attr->st_atim;
-  else if (to_set & FUSE_SET_ATTR_ATIME_NOW)
-    times[0].tv_nsec = UTIME_NOW;
+    {
+      times[0] = attr->st_atim;
+      if (to_set & FUSE_SET_ATTR_ATIME_NOW)
+        times[0].tv_nsec = UTIME_NOW;
+    }
 
   if (to_set & FUSE_SET_ATTR_MTIME)
-    times[1] = attr->st_mtim;
-  else if (to_set & FUSE_SET_ATTR_MTIME_NOW)
-    times[1].tv_nsec = UTIME_NOW;
+    {
+      times[1] = attr->st_mtim;
+      if (to_set & FUSE_SET_ATTR_MTIME_NOW)
+        times[1].tv_nsec = UTIME_NOW;
+    }
 
   if (times[0].tv_nsec != UTIME_OMIT || times[1].tv_nsec != UTIME_OMIT)
     {


### PR DESCRIPTION
When handling `setattr()` requests that involve changing the access/modification time, this library sets `tv_sec=UTIME_OMIT` or `tv_sec=UTIME_NOW` before calling `utimensat()` or `futimens()`:

https://github.com/containers/fuse-overlayfs/blob/11ad142525a606f327745210e709dcbd23844fd2/main.c#L3950-L3967

This is wrong. [`utimensat(2)`](https://man7.org/linux/man-pages/man2/utimensat.2.html) specifies that `UTIME_OMIT` or `UTIME_NOW` should be stored in **`tv_nsec`**, not `tv_sec`.

The way this bug manifests is that calling e.g. `utimensat(AT_FDCWD, "/overlay/file", [{.tv_nsec=UTIME_OMIT}, {...}], 0)` on a file in a fuse-overlayfs will cause file's access timestamp to be reset to `2004-01-10 13:37:02.000000000`. This time corresponds to a Unix timestamp of `1073741822`, which is the value of `UTIME_OMIT` on Linux.

The following C program can be used to verify this:

```c
#include <unistd.h>
#include <stdio.h>
#include <sys/stat.h>
#include <fcntl.h>
#include <time.h>

int main(int argc, char *argv[]) {
    if(argc < 2) {
        fputs("No file specified\n", stderr);
        return 1;
    }

    struct stat st;
    struct timespec times[2];

    // Error handling omitted for clarity

    // Create the file if it doesn't exist
    if(stat(argv[1], &st) < 0) {
        close(creat(argv[1], 0666));
    }

    times[0].tv_sec = 0;
    times[0].tv_nsec = UTIME_OMIT;
    clock_gettime(CLOCK_REALTIME, &times[1]);
    utimensat(AT_FDCWD, argv[1], times, 0);

    stat(argv[1], &st);
    printf("Access: %lu %ld\n", (unsigned long)st.st_atim.tv_sec, st.st_atim.tv_nsec);
    printf("Modification: %lu %ld\n", (unsigned long)st.st_mtim.tv_sec, st.st_mtim.tv_nsec);

    return 0;
}

```

Normal output:
```bash
$ ./ovfs-test /regular/file
Access: 1618363270 918256057
Modification: 1618363383 397989376
```

Output when run against a file on a fuse-overlayfs filesystem:
```bash
$ ./ovfs-test /overlay/file
Access: 1073741822 0  # tv_sec was reset to the value of UTIME_OMIT
Modification: 1618363378 710776870
```

## Second problem: "now" flags

This isn't a bug, but it's a case of the code not doing things the way it was intended to.

If the `atime` is `UTIME_NOW`, then the kernel sets `FUSE_SET_ATTR_ATIME | FUSE_SET_ATTR_ATIME_NOW` in the flags passed to FUSE. See [`iattr_to_fattr()`](https://github.com/torvalds/linux/blob/master/fs/fuse/dir.c#L1480).

However, the check for `FUSE_SET_ATTR_ATIME_NOW` in `main.c` is only done if `FUSE_SET_ATTR_ATIME` was not set. To work properly, it needs to check for `FUSE_SET_ATTR_ATIME_NOW` if `FUSE_SET_ATTR_ATIME` *was* set.

However, the code still works because FUSE sets `st_atim` to the current time if `UTIME_NOW` was passed, so the timestamp is still set to the current time. It isn't broken, but it's not doing what it looks like.

I see 2 paths to improve it: 1) remove the `FUSE_SET_ATTR_ATIME_NOW` check altogether, or 2) move it under the `FUSE_SET_ATTR_ATIME` check. I've done the latter in this PR, but I'd be happy to change it to do the former.

(All of this also applies to `st_mtim` and the corresponding flags.)

---

I've tried to match the surrounding formatting in this PR, but I'm happy to reformat if I missed something.