### PR TITLE
main: fix invalid access when filtering xattrs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,6 @@ jobs:
             sudo mkdir -p /lower /upper /mnt
             sudo sh -c "(cd /; git clone https://github.com/amir73il/unionmount-testsuite.git)"
             sudo go get github.com/containers/storage
-            sudo GOPATH=$GOPATH sh -c "(cd /root/go/src/github.com/containers/storage; make tests/tools/build/ffjson; cp tests/tools/build/ffjson /usr/bin)"
             sudo GOPATH=$GOPATH sh -c "(cd /root/go/src/github.com/containers/storage; sed -i -e 's|^AUTOTAGS.*$|AUTOTAGS := exclude_graphdriver_devicemapper exclude_graphdriver_btrfs|' Makefile; make GO111MODULE=on containers-storage)"
 
     - name: run autogen.sh

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+* fuse-overlayfs-1.6
+
+- fix an invalid access when filtering internal xattrs that could
+  deal to a segfault.
+
 * fuse-overlayfs-1.5
 
 - honor FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT also for renames

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [1.6], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [1.7-dev], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [1.6-dev], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [1.6], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/main.c
+++ b/main.c
@@ -944,7 +944,7 @@ node_free (void *p)
 
   if (n->parent)
     {
-      if (hash_lookup (n->parent->children, n) == n)
+      if (n->parent->children && hash_lookup (n->parent->children, n) == n)
         hash_delete (n->parent->children, n);
       n->parent->loaded = 0;
       n->parent = NULL;

--- a/main.c
+++ b/main.c
@@ -2474,6 +2474,42 @@ ovl_releasedir (fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
   fuse_reply_err (req, 0);
 }
 
+/* in-place filter xattrs that cannot be accessed.  */
+static ssize_t
+filter_xattrs_list (char *buf, ssize_t len)
+{
+  ssize_t ret = 0;
+  size_t i = 0;
+  char *it;
+
+  if (buf == NULL)
+    return len;
+
+  it = buf;
+
+  while (it < buf + len)
+    {
+      size_t it_len;
+
+      it_len = strlen (it) + 1;
+
+      if (can_access_xattr (it))
+        {
+          it += it_len;
+          ret += it_len;
+        }
+      else
+        {
+          char *next = it + it_len;
+
+          memmove (it, next, buf + len - next);
+          len -= it_len;
+        }
+    }
+
+  return ret;
+}
+
 static void
 ovl_listxattr (fuse_req_t req, fuse_ino_t ino, size_t size)
 {
@@ -2525,22 +2561,7 @@ ovl_listxattr (fuse_req_t req, fuse_ino_t ino, size_t size)
       return;
     }
 
-  len = ret;
-
-  for (i = 0; buf && i < len;)
-    {
-      size_t current_len;
-      const char *cur_attr = buf + i;
-
-      current_len = strlen (cur_attr) + 1;
-      if (can_access_xattr (cur_attr))
-        i += current_len;
-      else
-        {
-          memmove (buf + i, cur_attr + current_len, len - current_len);
-          len -= current_len;
-        }
-    }
+  len = filter_xattrs_list (buf, ret);
 
   if (size == 0)
     fuse_reply_xattr (req, len);


### PR DESCRIPTION
Fix an invalid access when filtering internal xattrs.
    
The size passed to memmove was longer than the remaining bytes to process.

As part of the fix: move the filtering logic to a separate function.

Closes: https://github.com/containers/fuse-overlayfs/issues/293

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
