### PR TITLE
fuse-overlayfs: fix read xattrs for devices

### DIFF
--- a/direct.c
+++ b/direct.c
@@ -43,17 +43,9 @@ direct_file_exists (struct ovl_layer *l, const char *pathname)
 static int
 direct_listxattr (struct ovl_layer *l, const char *path, char *buf, size_t size)
 {
-  cleanup_close int fd = -1;
   char full_path[PATH_MAX];
-  int ret;
 
-  full_path[0] = '\0';
-  ret = open_fd_or_get_path (l, path, full_path, &fd, O_RDONLY);
-  if (ret < 0)
-    return ret;
-
-  if (fd >= 0)
-    return flistxattr (fd, buf, size);
+  strconcat3 (full_path, PATH_MAX, l->path, "/", path);
 
   return llistxattr (full_path, buf, size);
 }
@@ -61,17 +53,9 @@ direct_listxattr (struct ovl_layer *l, const char *path, char *buf, size_t size)
 static int
 direct_getxattr (struct ovl_layer *l, const char *path, const char *name, char *buf, size_t size)
 {
-  cleanup_close int fd = -1;
   char full_path[PATH_MAX];
-  int ret;
 
-  full_path[0] = '\0';
-  ret = open_fd_or_get_path (l, path, full_path, &fd, O_RDONLY);
-  if (ret < 0)
-    return ret;
-
-  if (fd >= 0)
-    return fgetxattr (fd, name, buf, size);
+  strconcat3 (full_path, PATH_MAX, l->path, "/", path);
 
   return lgetxattr (full_path, name, buf, size);
 }

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -246,5 +246,8 @@ mkdir -p merged/a/b
 rm -rf merged/a/b
 test \! -e upper/a/b
 
+mknod merged/dev-foo c 10 175
+attr -l merged/dev-foo
+
 umount merged
 

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -204,8 +204,9 @@ fi
 touch merged/$(printf %${merged_max_filename_len}s | tr ' ' A})
 
 # If a file is removed but referenced, we must still be able to access it.
-echo 12345 > merged/toremove
-sleep 30 < merged/toremove &
+echo 12345 | tee merged/toremove
+cat merged/toremove
+sleep 90 < merged/toremove &
 sleep_pid=$!
 rm merged/toremove
 grep 12345 /proc/$sleep_pid/fd/0


### PR DESCRIPTION
always use llistxattr and lgetxattr for listing and reading xattrs so
that the open/openat2 call doesn't fail when accessing a device.

Closes: https://github.com/containers/fuse-overlayfs/issues/312

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>