### PR TITLE
main: fix check for FUSE_CAP_POSIX_ACL

### DIFF
--- a/main.c
+++ b/main.c
@@ -427,10 +427,10 @@ ovl_init (void *userdata, struct fuse_conn_info *conn)
   if ((conn->capable & FUSE_CAP_WRITEBACK_CACHE) == 0)
     lo->writeback = 0;
 
-  if ((conn->capable & FUSE_CAP_POSIX_ACL) == 0)
+  if (conn->capable & FUSE_CAP_POSIX_ACL)
     conn->want |= FUSE_CAP_POSIX_ACL;
 
-  conn->want |= FUSE_CAP_DONT_MASK | FUSE_CAP_SPLICE_READ | FUSE_CAP_SPLICE_WRITE | FUSE_CAP_SPLICE_MOVE | FUSE_CAP_POSIX_ACL;
+  conn->want |= FUSE_CAP_DONT_MASK | FUSE_CAP_SPLICE_READ | FUSE_CAP_SPLICE_WRITE | FUSE_CAP_SPLICE_MOVE;
   if (lo->writeback)
     conn->want |= FUSE_CAP_WRITEBACK_CACHE;
 }


### PR DESCRIPTION
fix the check for FUSE_CAP_POSIX_ACL.  commit
0a659e75ef61456bda1fa4b0b30117296f66f4fe introduced the issue.

It is needed to run fuse-overlayfs on RHEL 7 kernels.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>