### PR TITLE
NEWS: tag 1.7.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+* fuse-overlayfs-1.7.1
+
+- set FUSE_CAP_POSIX_ACL only when it is supported by FUSE.
+- treat statx failure with EINVAL as ENOSYS, so that the fallback
+  is attempted.
+
 * fuse-overlayfs-1.7
 
 - fix read xattrs for device files

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [1.7.1], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [1.8-dev], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [1.8-dev], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [1.7.1], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
- set FUSE_CAP_POSIX_ACL only when it is supported by FUSE.
- treat statx failure with EINVAL as ENOSYS, so that the fallback is attempted.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>