### PR TITLE
main: fix lookup if underlying file is a symlink

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+* fuse-overlayfs-1.8.2
+
+- main: fix lookup if underlying path is a symlink, but a directory on
+  a upper directory.
+
 * fuse-overlayfs-1.8.1
 
 - main: fix race when looking up an inode that was renamed.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [1.9-dev], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [1.8.2], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [1.8.2], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [1.9-dev], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -48,14 +48,14 @@ mkdir upper workdir lower
 fuse-overlayfs -o sync=0,lowerdir=lower,upperdir=upper,workdir=workdir,suid,dev merged
 
 # https://github.com/containers/fuse-overlayfs/issues/86
-docker run --rm -v $(pwd)/merged:/merged centos:8 yum --installroot /merged -y --releasever 8 install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+docker run --rm -v $(pwd)/merged:/merged quay.io/centos/centos:stream8 yum --installroot /merged -y --releasever 8 install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
 umount merged
 
 # fast_ino_check
 fuse-overlayfs -o fast_ino_check=1,sync=0,lowerdir=lower,upperdir=upper,workdir=workdir,suid,dev merged
 
-docker run --rm -v $(pwd)/merged:/merged centos:8 yum --installroot /merged -y --releasever 8 install nano
+docker run --rm -v $(pwd)/merged:/merged quay.io/centos/centos:stream8 yum --installroot /merged -y --releasever 8 install nano
 
 mkdir merged/a-directory
 

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -251,5 +251,17 @@ test \! -e upper/a/b
 mknod merged/dev-foo c 10 175
 attr -l merged/dev-foo
 
-umount merged
+# https://github.com/containers/fuse-overlayfs/issues/337
+umount -l merged
 
+rm -rf lower upper workdir merged
+mkdir lower upper workdir merged
+
+mkdir upper/foo
+ln -s not/existing lower/foo
+
+fuse-overlayfs -o lowerdir=lower,upperdir=upper,workdir=workdir merged
+
+stat merged/foo
+
+umount merged


### PR DESCRIPTION
fix lookup if the underlying file is a symlink, while it is a directory on the upper layer.

Closes: https://github.com/containers/fuse-overlayfs/issues/337

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>