### PR TITLE
release.yaml: add riscv64 build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,16 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: "Fetch buildx binary"
-      run: |
-        wget -O buildx https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64
-        chmod +x buildx
-    - name: "Initialize buildx"
-      run: |
-        ./buildx create --name cross --platform=amd64,arm,arm64,s390x,ppc64le  --use
-        ./buildx inspect --bootstrap
+    - uses: docker/setup-buildx-action@v1
     - name: "Build binaries from Containerfile.cross"
-      run: ./buildx build -o /tmp --platform=amd64,arm64,arm,s390x,ppc64le -f Containerfile.cross .
+      run: docker buildx build -o /tmp --platform=amd64,arm64,arm,s390x,ppc64le,riscv64 -f Containerfile.cross .
     - name: "Create /tmp/artifact"
       run: |
         mkdir -p /tmp/artifact
@@ -28,6 +21,7 @@ jobs:
         mv /tmp/linux_arm_v7/fuse-overlayfs /tmp/artifact/fuse-overlayfs-armv7l
         mv /tmp/linux_s390x/fuse-overlayfs /tmp/artifact/fuse-overlayfs-s390x
         mv /tmp/linux_ppc64le/fuse-overlayfs /tmp/artifact/fuse-overlayfs-ppc64le
+        mv /tmp/linux_riscv64/fuse-overlayfs /tmp/artifact/fuse-overlayfs-riscv64
     - name: "SHA256SUMS"
       run: (cd /tmp/artifact; sha256sum *) | tee /tmp/SHA256SUMS
     - name: "Create release"
@@ -83,6 +77,15 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: /tmp/artifact/fuse-overlayfs-ppc64le
         asset_name: fuse-overlayfs-ppc64le
+        asset_content_type: application/octet-stream
+    - name: "Upload fuse-overlayfs-riscv64"
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: /tmp/artifact/fuse-overlayfs-riscv64
+        asset_name: fuse-overlayfs-riscv64
         asset_content_type: application/octet-stream
     - name: "Upload SHA256SUMS"
       uses: actions/upload-release-asset@v1.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: "Register QEMU to /proc/sys/fs/binfmt_misc"
-      run: docker run --rm --privileged linuxkit/binfmt:v0.8
     - name: "Fetch buildx binary"
       run: |
         wget -O buildx https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64

--- a/Containerfile.cross
+++ b/Containerfile.cross
@@ -1,14 +1,16 @@
-FROM --platform=$BUILDPLATFORM debian:10 AS fuse-overlayfs
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.1.0 AS xx
+FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS fuse-overlayfs
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
-  git ca-certificates libc6-dev gcc make automake autoconf pkgconf libfuse3-dev file curl go-md2man
-RUN curl -o /cross.sh https://raw.githubusercontent.com/tonistiigi/binfmt/18c3d40ae2e3485e4de5b453e8460d6872b24d6b/binfmt/scripts/cross.sh && chmod +x /cross.sh
+  git make automake autoconf pkgconf file go-md2man
 COPY . /fuse-overlayfs
 WORKDIR /fuse-overlayfs
+COPY --from=xx / /
 ARG TARGETPLATFORM
-RUN /cross.sh install gcc pkgconf libfuse3-dev | sh
+ENV DEBIAN_FRONTEND=noninteractive
+RUN xx-apt-get install -y gcc libfuse3-dev
 RUN ./autogen.sh && \
-  CC=$(/cross.sh cross-prefix)-gcc LD=$(/cross.sh cross-prefix)-ld LIBS="-ldl" LDFLAGS="-static" ./configure && \
+  LIBS="-ldl" LDFLAGS="-static" ./configure --host=$(xx-info) && \
   make && mkdir /out && cp fuse-overlayfs /out && \
   file /out/fuse-overlayfs | grep "statically linked"
 


### PR DESCRIPTION
Test release: https://github.com/AkihiroSuda/fuse-overlayfs/releases/tag/test-cross-20220501-1
Build logs: https://github.com/AkihiroSuda/fuse-overlayfs/releases/tag/test-cross-20220501-1

- - -
The base image of Containerfile.cross is changed from debian:10 to ubuntu:22.04 for supporting riscv64.
This PR also contains several refactoring changes such as removing dependency on QEMU user mode emulation.