### PR TITLE
main: ignore EOVERFLOW when copying xattrs

### DIFF
--- a/main.c
+++ b/main.c
@@ -2699,7 +2699,11 @@ copy_xattr (int sfd, int dfd, char *buf, size_t buf_size)
 
           s = safe_read_xattr (&v, sfd, it, 256);
           if (s < 0)
-            return -1;
+           {
+             if (errno == EOVERFLOW)
+               continue;
+             return -1;
+           }
 
           if (fsetxattr (dfd, it, v, s, 0) < 0)
             {


### PR DESCRIPTION
the kernel returns EOVERFLOW if the rootid cannot be mapped in the
current user namespace when reading the file capabilities
(security.capabilities xattr).

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>