### PR TITLE
main: set correct value of `RENAME_NOREPLACE` ifndef `RENAME_EXACHANGE`

### DIFF
--- a/main.c
+++ b/main.c
@@ -124,9 +124,12 @@ open_by_handle_at (int mount_fd, struct file_handle *handle, int flags)
 }
 #endif
 
+#ifndef RENAME_NOREPLACE
+# define RENAME_NOREPLACE (1 << 0)
+#endif
+
 #ifndef RENAME_EXCHANGE
 # define RENAME_EXCHANGE (1 << 1)
-# define RENAME_NOREPLACE (1 << 2)
 #endif
 
 #ifndef RENAME_WHITEOUT


### PR DESCRIPTION
Set correct value of `RENAME_NOREPLACE` when `RENAME_EXCHANGE` is not
already defined i.e use `1 << 0` instead of `1 << 2` which seems
incorrect.

Reference: https://github.com/torvalds/linux/blob/f2906aa863381afb0015a9eb7fefad885d4e5a56/include/uapi/linux/fs.h#L50-L52

Closes: https://github.com/containers/fuse-overlayfs/issues/353