### PR TITLE
direct: use /proc/self/fd to read xattrs

### DIFF
--- a/direct.c
+++ b/direct.c
@@ -44,8 +44,13 @@ static int
 direct_listxattr (struct ovl_layer *l, const char *path, char *buf, size_t size)
 {
   char full_path[PATH_MAX];
-
-  strconcat3 (full_path, PATH_MAX, l->path, "/", path);
+  int ret;
+  ret = snprintf (full_path, sizeof (full_path), "/proc/self/fd/%d/%s", l->fd, path);
+  if (ret >= sizeof (full_path))
+    {
+      errno = ENAMETOOLONG;
+      return -1;
+    }
 
   return llistxattr (full_path, buf, size);
 }
@@ -54,9 +59,13 @@ static int
 direct_getxattr (struct ovl_layer *l, const char *path, const char *name, char *buf, size_t size)
 {
   char full_path[PATH_MAX];
-
-  strconcat3 (full_path, PATH_MAX, l->path, "/", path);
-
+  int ret;
+  ret = snprintf (full_path, sizeof (full_path), "/proc/self/fd/%d/%s", l->fd, path);
+  if (ret >= sizeof (full_path))
+    {
+      errno = ENAMETOOLONG;
+      return -1;
+    }
   return lgetxattr (full_path, name, buf, size);
 }
 


### PR DESCRIPTION
instead of using the lgetxattr and llistxattr system calls on the
entire file path, use the /proc/self/fd/$FD/$RELATIVE_PATH path
instead so that the lookup is relative to the lower dir file
descriptor that is already open.

Closes: https://github.com/containers/fuse-overlayfs/issues/364

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>