### PR TITLE
upload builds from CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,8 +38,15 @@ jobs:
 
           run: |
             ./autogen.sh
-            ./configure
+            LIBS="-ldl" LDFLAGS="-static" ./configure
             make -j $(nproc)
+
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: fuse-overlayfs-${{ matrix.arch }}-${{ matrix.distro }}
+          path: |
+            fuse-overlayfs
 
   Test:
     runs-on: ubuntu-20.04
@@ -72,13 +79,21 @@ jobs:
 
     - name: run configure
       run: |
-        ./configure
+        LIBS="-ldl" LDFLAGS="-static" ./configure
 
     - name: build and install
       run: |
         make -j $(nproc)
         sudo make -j install
         sudo cp fuse-overlayfs /sbin
+
+    - name: Archive build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: fuse-overlayfs-x86_64-ubuntu20.04
+        path: |
+          fuse-overlayfs
+      if: ${{ matrix.test == 'ovl-whiteouts' }}
 
     - name: run test
       run: |


### PR DESCRIPTION
Upload fuse-overlayfs as job artifacts on CI.

Context: I [was asked](https://github.com/NVIDIA/enroot/issues/132#issuecomment-1219025116) to try the latest commit of fuse-overlayfs to see whether it fixes an issue in enroot.

When trying to install buildah on ubuntu 20.04 a couple of days ago, I got a conflict for `runc` (runc vs moby-runc).
After removing the conflicting dependency, I ran the container but still ran into errors, both for `Containerfile.static.ubuntu` and `Containerfile.static.fedora` (maybe related to access to package repositories from the Azure VM, I didn't write down the issue), and I stopped.

If I understand correctly, then `fuse-overlayfs` is anyhow a standalone binary that needs to be built only once for a given architecture (?), and this already happens in your CI setup.

This PR makes the builds on various architectures available for download as artifacts from the workflow build ([build on my fork](https://github.com/ltalirz/fuse-overlayfs/actions/runs/2972743882)).
<img width="691" alt="image" src="https://user-images.githubusercontent.com/1053245/187952793-c56d631f-44cf-4cc8-be7f-ac7484a9f4c2.png">


If you'd be interested in adding this to the CI, I can restrict the artifact upload to runs on the `main` branch, so this does not happen on PRs / "experimental" builds.
One can also set a retention limit for these artifacts (e.g. 180 days) if desired.


If not - no problem, and feel free to close the PR.