### PR TITLE
main: fix performance issue with large dirs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+* fuse-overlayfs-1.13
+
+- fix a performance issue when dealing with big directories.
+
 * fuse-overlayfs-1.12
 
 - change license to GPL-2.0-or-later.

--- a/fuse-overlayfs.h
+++ b/fuse-overlayfs.h
@@ -54,6 +54,8 @@ struct ovl_node
   struct ovl_node *next_link;
   unsigned int in_readdir;
 
+  size_t n_links;
+
   unsigned int do_unlink : 1;
   unsigned int do_rmdir : 1;
   unsigned int hidden : 1;


### PR DESCRIPTION
cache the number of links for a directory instead of calculating it on every stat.  It makes a huge difference when the directory has a lot of entries.

Closes: https://github.com/containers/fuse-overlayfs/issues/401

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
