### PR TITLE
release.yaml: migrate from `hub` to `gh`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,10 +52,7 @@ jobs:
       run: sha256sum /tmp/SHA256SUMS
     - name: "Prepare the release note"
       run: |
-        tag="${GITHUB_REF##*/}"
         cat << EOF | tee /tmp/release-note.txt
-        ${tag}
-
         #### About the binaries
         The binaries were built automatically on GitHub Actions.
         The build log is available for 90 days: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -77,6 +74,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         tag="${GITHUB_REF##*/}"
-        asset_flags=()
-        for f in /tmp/artifact/* /tmp/SHA256SUMS; do asset_flags+=("-a" "$f"); done
-        hub release create "${asset_flags[@]}" -F /tmp/release-note.txt --draft "${tag}"
+        gh release create -F /tmp/release-note.txt --draft --title "${tag}" "${tag}" /tmp/artifact/* /tmp/SHA256SUMS


### PR DESCRIPTION
`hub` was deprecated and removed from GitHub Actions runners:
- https://github.com/actions/runner-images/issues/8362