### PR TITLE
.clang-format: remove duplicated mapping key which breaks newer `clang` formatters.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,12 +23,6 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: true
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: false
-AllowShortBlocksOnASingleLine: false
-BreakBeforeBraces: Allman
 BraceWrapping:
   AfterCaseLabel:  true
   AfterClass:      true


### PR DESCRIPTION
New clang versions throw error like below, following commit fixes that

```console
.clang-format:26:1: error: duplicated mapping key 'AllowShortIfStatementsOnASingleLine'
AllowShortIfStatementsOnASingleLine: false
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Version which i tried: `clang-format version 17.0.6`

Following change should not produce any diff in `.c` or `.h` files.