### PR TITLE
utils: Always suppress ENODATA

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -270,14 +270,10 @@ override_mode (struct ovl_layer *l, int fd, const char *abs_path, const char *pa
   if (fd >= 0)
     {
       ret = fgetxattr (fd, xattr_name, buf, sizeof (buf) - 1);
-      if (ret < 0)
-        return ret;
     }
   else if (abs_path)
     {
       ret = lgetxattr (abs_path, xattr_name, buf, sizeof (buf) - 1);
-      if (ret < 0)
-        return ret;
     }
   else
     {
@@ -292,15 +288,11 @@ override_mode (struct ovl_layer *l, int fd, const char *abs_path, const char *pa
       if (fd >= 0)
         ret = fgetxattr (fd, xattr_name, buf, sizeof (buf) - 1);
       else
-        {
-          ret = lgetxattr (full_path, xattr_name, buf, sizeof (buf) - 1);
-          if (ret < 0 && errno == ENODATA)
-            return 0;
-        }
-
-      if (ret < 0)
-        return ret;
+        ret = lgetxattr (full_path, xattr_name, buf, sizeof (buf) - 1);
     }
+
+  if (ret < 0)
+    return errno == ENODATA ? 0 : ret;
 
   buf[ret] = '\0';
 


### PR DESCRIPTION
override_mode () used to suppress ENODATA only in a certain condition. ENODATA errors in other situations made load_dir () fail because it indirectly calls override_mode () when the underlying file system reports DT_UNKNOWN for an opaque whiteout file and such an file does not have mode xattrs. do_fchmod () and do_chmod () worked around the problem by supressing ENODATA by themselves, but that led to code duplication. Always suppress ENODATA to resolve these problems.