### PR TITLE
Update AC_INIT to 1.15-dev

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([fuse-overlayfs], [1.13-dev], [giuseppe@scrivano.org])
+AC_INIT([fuse-overlayfs], [1.15-dev], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
The version string should update as "1.14" when we have stable release:

    -AC_INIT([fuse-overlayfs], [1.13-dev], [giuseppe@scrivano.org])
    +AC_INIT([fuse-overlayfs], [1.14], [giuseppe@scrivano.org])

But since we had already get
https://github.com/containers/fuse-overlayfs/releases/tag/v1.14 since 2024-06-28, here we bump the version string to "1.15-dev" for next stable release.

Fixes https://github.com/containers/fuse-overlayfs/issues/438