### PR TITLE
Cargo.toml: add boilerplate to register a crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,21 @@
 name = "fuse-overlayfs"
 version = "2.0.0"
 edition = "2024"
+rust-version = "1.85.0"
 license = "GPL-2.0-or-later"
 description = "Overlay Filesystem in Userspace"
+repository = "https://github.com/containers/fuse-overlayfs"
+homepage = "https://github.com/containers/fuse-overlayfs"
+readme = "README.md"
+keywords = ["fuse", "overlayfs", "filesystem", "containers"]
+categories = ["filesystem"]
+exclude = [
+    ".github/",
+    "tests/",
+    "clippy",
+    "Containerfile.*",
+    "AGENTS.md",
+]
 
 [dependencies]
 fuser = { version = "0.17.0", features = ["abi-7-40"] }

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -36,7 +36,7 @@ fn read_proc_id(path: &str) -> Option<u32> {
 /// Format: colon-separated triples of host:to:len.
 pub fn parse_mappings(s: &str) -> Result<Vec<IdMapping>, String> {
     let parts: Vec<&str> = s.split(':').filter(|p| !p.is_empty()).collect();
-    if !parts.len().is_multiple_of(3) {
+    if parts.len() % 3 != 0 {
         return Err(format!("invalid mapping specified: {}", s));
     }
 


### PR DESCRIPTION
@Luap99 @saschagrunert  PTAL

I've already registered the crate using this version of the file: https://crates.io/crates/fuse-overlayfs