### PR TITLE
fuse-overlayfs: replace eprintln! with log crate macros

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 // CLI option parsing. Replicates the exact -o key=value syntax from the C version.
 
 use crate::mapping::{self, IdMapping};
+use log::warn;
 
 /// All configuration parsed from the command line.
 #[derive(Debug)]
@@ -178,7 +179,7 @@ pub fn parse_args(args: &[String]) -> Result<OverlayConfig, String> {
         }
 
         if arg.starts_with('-') {
-            eprintln!("unknown argument ignored: {}", arg);
+            warn!("unknown argument ignored: {}", arg);
             i += 1;
             continue;
         }
@@ -345,7 +346,7 @@ fn parse_single_option(opt: &str, config: &mut OverlayConfig) -> Result<(), Stri
                 if FUSE_PASSTHROUGH_OPTS.contains(&key) {
                     config.fuse_options.push(opt.to_string());
                 } else {
-                    eprintln!("unknown argument ignored: {}", opt);
+                    warn!("unknown argument ignored: {}", opt);
                 }
             }
         }
@@ -368,7 +369,7 @@ fn parse_single_option(opt: &str, config: &mut OverlayConfig) -> Result<(), Stri
             if FUSE_PASSTHROUGH_OPTS.contains(&opt) {
                 config.fuse_options.push(opt.to_string());
             } else {
-                eprintln!("unknown argument ignored: {}", opt);
+                warn!("unknown argument ignored: {}", opt);
             }
         }
     }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -8,6 +8,7 @@ use crate::error::{FsError, FsResult};
 use crate::sys::handle;
 use crate::sys::openat2::{self, SafeFd};
 use crate::sys::xattr as sxattr;
+use log::warn;
 use std::ffi::CString;
 use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 
@@ -63,7 +64,7 @@ impl DataSource for DirectAccess {
         let resolved = match crate::sys::fs::realpath(&c_path) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("cannot resolve path {}", path);
+                warn!("cannot resolve path {}", path);
                 return Err(e);
             }
         };

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -3,6 +3,7 @@
 // Layer management: represents a single overlay layer (lower or upper).
 
 use crate::datasource::{DataSource, StatOverrideMode};
+use log::warn;
 use std::os::fd::RawFd;
 
 /// A single overlay layer.
@@ -73,7 +74,7 @@ pub fn init_layers(
     for dir in &dirs {
         let plugin = config::parse_plugin_path(dir);
         if plugin.is_some() {
-            eprintln!("plugin layers not yet implemented: {}", dir);
+            warn!("plugin layers not yet implemented: {}", dir);
             continue;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,20 @@ mod sys;
 mod whiteout;
 mod xattr;
 
-use log::info;
+use log::{debug, error, info, warn};
 use std::os::fd::{AsRawFd, OwnedFd};
 
 fn main() {
-    // Support FUSE_OVERLAYFS_DEBUG_LOG=/path/to/file for logging in daemon mode
+    let args: Vec<String> = std::env::args().collect();
+    let config = match config::parse_args(&args) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("fuse-overlayfs: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    // Initialize logger after config parsing so --debug can set the level.
     if let Ok(log_path) = std::env::var("FUSE_OVERLAYFS_DEBUG_LOG") {
         let file = std::fs::OpenOptions::new()
             .create(true)
@@ -34,23 +43,26 @@ fn main() {
             .target(env_logger::Target::Pipe(Box::new(file)))
             .init();
     } else {
-        env_logger::init();
+        let default_level = if config.debug {
+            log::LevelFilter::Debug
+        } else {
+            log::LevelFilter::Warn
+        };
+        env_logger::Builder::new()
+            .filter_level(default_level)
+            .parse_default_env()
+            .format(|buf, record| {
+                use std::io::Write;
+                writeln!(buf, "fuse-overlayfs: {}", record.args())
+            })
+            .init();
     }
-
-    let args: Vec<String> = std::env::args().collect();
-    let config = match config::parse_args(&args) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("fuse-overlayfs: {}", e);
-            std::process::exit(1);
-        }
-    };
 
     // Validate required options
     let lowerdir = match &config.lowerdir {
         Some(l) => l.clone(),
         None => {
-            eprintln!("fuse-overlayfs: no lowerdir specified");
+            error!("no lowerdir specified");
             std::process::exit(1);
         }
     };
@@ -58,13 +70,13 @@ fn main() {
     let mountpoint = match &config.mountpoint {
         Some(m) => m.clone(),
         None => {
-            eprintln!("fuse-overlayfs: no mountpoint specified");
+            error!("no mountpoint specified");
             std::process::exit(1);
         }
     };
 
     if config.redirect_dir.as_deref().is_some_and(|r| r != "off") {
-        eprintln!("fuse-overlayfs: fuse-overlayfs only supports redirect_dir=off");
+        error!("fuse-overlayfs only supports redirect_dir=off");
         std::process::exit(1);
     }
 
@@ -79,7 +91,7 @@ fn main() {
         match sys::openat2::open_trusted(wd, libc::O_DIRECTORY, 0) {
             Ok(fd) => fd,
             Err(e) => {
-                eprintln!("fuse-overlayfs: cannot open workdir {}: {}", wd, e);
+                error!("cannot open workdir {}: {}", wd, e);
                 std::process::exit(1);
             }
         }
@@ -95,26 +107,26 @@ fn main() {
     ) {
         Ok(l) => l,
         Err(e) => {
-            eprintln!("fuse-overlayfs: {}", e);
+            error!("{}", e);
             std::process::exit(1);
         }
     };
 
     if config.debug {
-        eprintln!("uid={}", config.uid_str.as_deref().unwrap_or("unchanged"));
-        eprintln!("gid={}", config.gid_str.as_deref().unwrap_or("unchanged"));
-        eprintln!(
+        debug!("uid={}", config.uid_str.as_deref().unwrap_or("unchanged"));
+        debug!("gid={}", config.gid_str.as_deref().unwrap_or("unchanged"));
+        debug!(
             "upperdir={}",
             config.upperdir.as_deref().unwrap_or("NOT USED")
         );
-        eprintln!(
+        debug!(
             "workdir={}",
             config.workdir.as_deref().unwrap_or("NOT USED")
         );
-        eprintln!("lowerdir={}", &lowerdir);
-        eprintln!("mountpoint={}", &mountpoint);
-        eprintln!("plugins={}", config.plugins.as_deref().unwrap_or("<none>"));
-        eprintln!(
+        debug!("lowerdir={}", &lowerdir);
+        debug!("mountpoint={}", &mountpoint);
+        debug!("plugins={}", config.plugins.as_deref().unwrap_or("<none>"));
+        debug!(
             "fsync={}",
             if config.fsync { "enabled" } else { "disabled" }
         );
@@ -177,7 +189,7 @@ fn main() {
     let session = match fuser::Session::new(fs, std::path::Path::new(&mountpoint), &fuse_config) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("fuse-overlayfs: mount failed: {}", e);
+            error!("mount failed: {}", e);
             std::process::exit(1);
         }
     };
@@ -197,13 +209,13 @@ fn main() {
     let bg = match session.spawn() {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("fuse-overlayfs: session error: {}", e);
+            error!("session error: {}", e);
             std::process::exit(1);
         }
     };
 
     if let Err(e) = bg.join() {
-        eprintln!("fuse-overlayfs: session error: {}", e);
+        error!("session error: {}", e);
         std::process::exit(1);
     }
 }
@@ -219,7 +231,7 @@ fn set_limits() {
                 maximum: Some(hard),
             },
         ) {
-            eprintln!("fuse-overlayfs: cannot set nofile rlimit: {}", e);
+            warn!("cannot set nofile rlimit: {}", e);
         }
     }
 }
@@ -248,7 +260,7 @@ fn setup_sigusr1() {
     let mut signals = match Signals::new([SIGUSR1]) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("fuse-overlayfs: cannot register SIGUSR1 handler: {}", e);
+            warn!("cannot register SIGUSR1 handler: {}", e);
             return;
         }
     };
@@ -274,15 +286,15 @@ fn check_writeable_proc() {
     let sfs = match sys::fs::statfs(&c_proc) {
         Ok(s) => s,
         Err(_) => {
-            eprintln!("fuse-overlayfs: error stating /proc");
+            warn!("error stating /proc");
             return;
         }
     };
 
     const PROC_SUPER_MAGIC: i64 = 0x9fa0;
     if sfs.f_type as i64 != PROC_SUPER_MAGIC {
-        eprintln!(
-            "fuse-overlayfs: invalid file system type found on /proc: {}, expected {}",
+        warn!(
+            "invalid file system type found on /proc: {}, expected {}",
             sfs.f_type, PROC_SUPER_MAGIC
         );
         return;
@@ -291,8 +303,6 @@ fn check_writeable_proc() {
     if let Ok(stvfs) = sys::fs::statvfs(&c_proc)
         && (stvfs.f_flag & libc::ST_RDONLY) != 0
     {
-        eprintln!(
-            "fuse-overlayfs: /proc seems to be mounted as readonly, it can lead to unexpected failures"
-        );
+        warn!("/proc seems to be mounted as readonly, it can lead to unexpected failures");
     }
 }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -25,7 +25,7 @@ use fuser::{
     ReplyDirectoryPlus, ReplyEmpty, ReplyEntry, ReplyIoctl, ReplyLseek, ReplyOpen, ReplyStatfs,
     ReplyWrite, ReplyXattr, Request, TimeOrNow,
 };
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 
 /// Convert a string to CString, returning EINVAL on failure (interior null byte).
 /// Use in FUSE handlers where panicking is not acceptable.
@@ -2395,7 +2395,7 @@ impl Filesystem for OverlayFs {
             let (sid, did) = match (src_child, dst_child) {
                 (Some(s), Some(d)) => (s, d),
                 _ => {
-                    log::error!(
+                    error!(
                         "RENAME_EXCHANGE: in-memory children missing after successful renameat2"
                     );
                     reply.error(Errno::EIO);

--- a/src/sys/process.rs
+++ b/src/sys/process.rs
@@ -3,6 +3,8 @@
 // Safe wrappers for process-related syscalls.
 // All unsafe libc FFI calls are contained here.
 
+use log::error;
+
 /// Daemonize the process: fork, setsid, redirect stdio to /dev/null.
 /// Parent exits with status 0, child continues.
 pub fn daemonize() {
@@ -11,7 +13,7 @@ pub fn daemonize() {
     unsafe {
         let pid = libc::fork();
         if pid < 0 {
-            eprintln!("fuse-overlayfs: fork failed");
+            error!("fork failed");
             std::process::exit(1);
         }
         if pid > 0 {
@@ -21,7 +23,7 @@ pub fn daemonize() {
 
         // Child: new session
         if libc::setsid() < 0 {
-            eprintln!("fuse-overlayfs: setsid failed");
+            error!("setsid failed");
             std::process::exit(1);
         }
 
@@ -32,7 +34,7 @@ pub fn daemonize() {
                 || libc::dup2(devnull, 1) < 0
                 || libc::dup2(devnull, 2) < 0
             {
-                eprintln!("fuse-overlayfs: dup2 failed");
+                error!("dup2 failed");
                 std::process::exit(1);
             }
             if devnull > 2 {


### PR DESCRIPTION
Move env_logger initialization after config parsing so --debug can set the log level.  Use error!/warn!/debug! instead of raw eprintln! throughout the codebase, with a custom format that preserves the "fuse-overlayfs: " prefix.


@cgwalters FYI