### PR TITLE
copyup: fix directory permissions during copy-up

### DIFF
--- a/src/copyup.rs
+++ b/src/copyup.rs
@@ -165,12 +165,33 @@ pub fn create_node_directory(
     // Create temp dir in workdir
     let (wd_name, c_wd_name) = next_wd_name(wd_counter);
 
-    fs::mkdirat(workdir_fd, &c_wd_name, st.st_mode | 0o755)?;
+    let stat_override_mode = upper.stat_override_mode();
+    let backing_mode = if stat_override_mode != crate::datasource::StatOverrideMode::None {
+        st.st_mode | 0o755
+    } else {
+        st.st_mode
+    };
+    fs::mkdirat(workdir_fd, &c_wd_name, backing_mode)?;
 
     // Open the new dir to set ownership/xattrs/timestamps
     let dfd = openat2::safe_openat(workdir_fd, wd_name.as_bytes(), libc::O_RDONLY, 0)?;
 
-    let _ = fs::fchown(dfd.as_raw_fd(), st.st_uid, st.st_gid);
+    if stat_override_mode != crate::datasource::StatOverrideMode::None {
+        let xattr_name = match stat_override_mode {
+            crate::datasource::StatOverrideMode::User
+            | crate::datasource::StatOverrideMode::Containers => {
+                crate::datasource::XATTR_OVERRIDE_CONTAINERS_STAT
+            }
+            crate::datasource::StatOverrideMode::Privileged => {
+                crate::datasource::XATTR_PRIVILEGED_OVERRIDE_STAT
+            }
+            crate::datasource::StatOverrideMode::None => unreachable!(),
+        };
+        let override_val = format!("{}:{}:{:o}", st.st_uid, st.st_gid, st.st_mode & 0o7777);
+        let _ = sxattr::fsetxattr(dfd.as_raw_fd(), xattr_name, override_val.as_bytes(), 0);
+    } else {
+        let _ = fs::fchown(dfd.as_raw_fd(), st.st_uid, st.st_gid);
+    }
     let _ = fs::futimens(dfd.as_raw_fd(), &times);
 
     // Copy xattrs from source to new dir

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,8 +123,8 @@ fn main() {
             "workdir={}",
             config.workdir.as_deref().unwrap_or("NOT USED")
         );
-        debug!("lowerdir={}", &lowerdir);
-        debug!("mountpoint={}", &mountpoint);
+        debug!("lowerdir={}", lowerdir);
+        debug!("mountpoint={}", mountpoint);
         debug!("plugins={}", config.plugins.as_deref().unwrap_or("<none>"));
         debug!(
             "fsync={}",
@@ -185,7 +185,7 @@ fn main() {
     let fs = overlay::OverlayFs::new(config, layers, workdir_raw_fd, notifier_lock.clone());
 
     // Mount the filesystem (this creates the FUSE session and mounts)
-    info!("mounting on {} with {} threads", &mountpoint, n_threads);
+    info!("mounting on {} with {} threads", mountpoint, n_threads);
     let session = match fuser::Session::new(fs, std::path::Path::new(&mountpoint), &fuse_config) {
         Ok(s) => s,
         Err(e) => {

--- a/tests/test-copyup.sh
+++ b/tests/test-copyup.sh
@@ -231,4 +231,47 @@ done
 umount merged
 rm -rf lower upper workdir merged
 
+# ========================================
+# Test 11: Copy-up directory preserves restrictive permissions
+# Regression test for issue #470: directory permissions permanently
+# widened to 0755 during copy-up in create_node_directory()
+# ========================================
+echo "=== Test 11: Copy-up directory preserves restrictive permissions ==="
+mkdir -p lower upper workdir merged
+
+mkdir -p lower/privatedir
+echo "secret" > lower/privatedir/secret.txt
+chmod 0700 lower/privatedir
+
+mkdir -p lower/restricteddir
+echo "data" > lower/restricteddir/data.txt
+chmod 0750 lower/restricteddir
+
+mkdir -p lower/minimaldir
+chmod 0100 lower/minimaldir
+
+fuse-overlayfs -o lowerdir=lower,upperdir=upper,workdir=workdir merged
+
+# Trigger copy-up of privatedir by creating a file inside it
+echo "new" > merged/privatedir/newfile
+
+# Verify permissions in upper layer are preserved (not widened to 0755)
+upper_mode=$(stat -c '%a' upper/privatedir)
+test "$upper_mode" = "700" || { echo "FAIL: expected 700, got $upper_mode"; exit 1; }
+
+# Trigger copy-up of restricteddir
+echo "new" > merged/restricteddir/newfile
+upper_mode=$(stat -c '%a' upper/restricteddir)
+test "$upper_mode" = "750" || { echo "FAIL: expected 750, got $upper_mode"; exit 1; }
+
+# Verify through the merged view as well
+merged_mode=$(stat -c '%a' merged/privatedir)
+test "$merged_mode" = "700" || { echo "FAIL: expected merged 700, got $merged_mode"; exit 1; }
+
+merged_mode=$(stat -c '%a' merged/restricteddir)
+test "$merged_mode" = "750" || { echo "FAIL: expected merged 750, got $merged_mode"; exit 1; }
+
+umount merged
+rm -rf lower upper workdir merged
+
 echo "All copy-up tests passed!"


### PR DESCRIPTION
Match the C create_directory() behavior: only widen directory permissions when xattr_permissions is enabled, and store the original mode in the override xattr. Without xattr_permissions, use the original mode directly.

Fixes: https://github.com/containers/fuse-overlayfs/issues/470