### PR TITLE
docs: document FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT env var

### DIFF
--- a/fuse-overlayfs.1
+++ b/fuse-overlayfs.1
@@ -214,6 +214,49 @@ $ stat \-c %u:%g merged/a merged/b
 Those are the same IDs visible from outside the user namespace.
 
 
+.SH ENVIRONMENT
+.TP
+\fBFUSE\_OVERLAYFS\_DISABLE\_OVL\_WHITEOUT\fP
+.RS
+If set (to any value), disable the use of overlay whiteouts (character
+devices with major/minor 0:0, including the atomic
+\fBrenameat2\fP(\fIRENAME\_WHITEOUT\fP) path) and always create the portable
+\fB\.wh\.\fP style whiteout files instead.
+
+Background: the lowerdirs are read\-only, so deleting (or replacing) a file
+that exists in a lower layer cannot modify that layer.  Instead the
+deletion is recorded in the upperdir as a \fIwhiteout\fP entry that hides
+the lower\-layer name when the layers are merged.  Container image builds
+rely on this constantly: each \fBRUN\fP/\fBCOPY\fP step commits a new
+layer, so replacing a file from an earlier step means deleting it in the
+new layer.  When whiteout creation silently fails, those deletions become
+no\-ops and the subsequent create fails with \fBEEXIST\fP (\fIFile exists\fP).
+
+This is useful on kernels or filesystems where the \fIRENAME\_WHITEOUT\fP
+flag or device whiteouts are unavailable or silently broken (e.g. inside
+some virtual machines), since \fB\.wh\.\fP whiteouts only require regular
+file creation.
+
+For example, nested podman running inside a krun VM (e.g. started with
+\fBpodman \-\-runtime=krun\fP) can hit a guest kernel that accepts
+\fBrenameat2\fP(\fIRENAME\_WHITEOUT\fP) yet never creates the whiteout;
+container builds in the nested podman then fail with errors like:
+
+.RS
+.nf
+dpkg: error: error creating new backup file '/var/lib/dpkg/status-old': File exists
+Error: building at STEP "COPY . .": ... open /package.json: file exists
+.fi
+.RE
+
+Setting \fBFUSE\_OVERLAYFS\_DISABLE\_OVL\_WHITEOUT=1\fP in the environment
+of the nested podman (it is inherited by the storage driver's
+\fBmount\_program\fP) makes such builds work again.
+
+This is also the mode exercised by the CI "no\-ovl\-whiteouts" test lane.
+.RE
+
+
 .SH SEE ALSO
 .PP
 \fBfuse\fP(8), \fBmount\fP(8), \fBuser\_namespaces\fP(7)

--- a/fuse-overlayfs.1.md
+++ b/fuse-overlayfs.1.md
@@ -156,6 +156,47 @@ $ stat -c %u:%g merged/a merged/b
 
 Those are the same IDs visible from outside the user namespace.
 
+# ENVIRONMENT
+
+**FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT**
+
+:   If set (to any value), disable the use of overlay whiteouts (character
+    devices with major/minor 0:0, including the atomic
+    **renameat2**(**RENAME_WHITEOUT**) path) and always create the portable
+    `.wh.` style whiteout files instead.
+
+    Background: the lowerdirs are read-only, so deleting (or replacing) a
+    file that exists in a lower layer cannot modify that layer.  Instead
+    the deletion is recorded in the upperdir as a *whiteout* entry that
+    hides the lower-layer name when the layers are merged.  Container
+    image builds rely on this constantly: each `RUN`/`COPY` step commits
+    a new layer, so replacing a file from an earlier step means deleting
+    it in the new layer.  When whiteout creation silently fails, those
+    deletions become no-ops and the subsequent create fails with
+    `EEXIST` (`File exists`).
+
+    This is useful on kernels or filesystems where the RENAME_WHITEOUT
+    flag or device whiteouts are unavailable or silently broken (e.g.
+    inside some virtual machines), since `.wh.` whiteouts only require
+    regular file creation.
+
+    For example, nested podman running inside a krun VM (e.g. started
+    with `podman --runtime=krun`) can hit a guest kernel that accepts
+    **renameat2**(**RENAME_WHITEOUT**) yet never creates the whiteout;
+    container builds in the nested podman then fail with errors like:
+
+    ```
+    dpkg: error: error creating new backup file '/var/lib/dpkg/status-old': File exists
+    Error: building at STEP "COPY . .": ... open /package.json: file exists
+    ```
+
+    Setting `FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT=1` in the environment
+    of the nested podman (it is inherited by the storage driver's
+    `mount_program`) makes such builds work again.
+
+    This is also the mode exercised by the CI "no-ovl-whiteouts" test
+    lane.
+
 # SEE ALSO
 
 **fuse**(8), **mount**(8), **user_namespaces**(7)


### PR DESCRIPTION
## What this adds

An `ENVIRONMENT` section to the man page (both `fuse-overlayfs.1.md` and the
pre-rendered `fuse-overlayfs.1`) documenting `FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT`
— which until now existed nowhere except the source itself and a single NEWS
changelog line.

## Why: the debugging session that motivated this

The environment where this was hit:

- Arch Linux host, rootless podman
- a Debian (trixie) container started with `podman run --runtime=krun`
  (libkrun micro-VM)
- inside that container: a **nested** podman + podman-compose, its storage on a
  virtiofs bind mount back to the host, using fuse-overlayfs as the overlay
  `mount_program`

`podman compose up` was building a batch of images, and they failed for
strange reasons — all variations of `File exists`:

```
dpkg: error: error creating new backup file '/var/lib/dpkg/status-old': File exists
E: Sub-process /usr/bin/dpkg returned an error code (2)
```

```
Error: building at STEP "COPY . .": ... error opening file "/package.json" for writing: open /package.json: file exists
```

Minimal reproduction is a 4-line Dockerfile (no concurrency, no stale state):

```dockerfile
FROM busybox
WORKDIR /app
COPY package.json ./
COPY . .        # -> "open /package.json: file exists"
```

Root cause, found by stracing fuse-overlayfs while deleting a lower-layer file:

```
renameat(5, "4", 4, "d/keep")                    = 0   # copy-up into upper (OK)
renameat2(4, "d/keep", 5, "5", RENAME_WHITEOUT)  = 0   # SUCCESS — but no whiteout is created!
```

The krun guest kernel accepts `renameat2(RENAME_WHITEOUT)` without ever
creating the whiteout. fuse-overlayfs trusts the return value, marks
`whiteout_created = true`, and never falls back to `.wh.` files — so the
delete silently no-ops and the subsequent create fails with `EEXIST`.

Initially I started writing a patch to fuse-overlayfs to skip the broken
`RENAME_WHITEOUT` path (an LLM-assisted investigation with Qwen 3.8 27B and
GLM 5-3), then discovered this environment variable already existed for
exactly this case: setting `FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT=1` forces the
portable `.wh.` whiteouts and everything works again.

## Why it's worth documenting

The variable has existed since v0.2 (commit 4d7ac8d, 2018) and is still
honored by the current Rust implementation (`src/overlay.rs`), but:

- it is not mentioned in the man page or README
- it has zero mentions in any GitHub issue or PR, ever
- a web-wide literal search returns 3 hits, all mirrors of the v1.5 NEWS line
  ("honor FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT also for renames")
- it only appears in the source and in the CI `no-ovl-whiteouts` test lane

So the only realistic ways to find it today are reading `main.c`/`overlay.rs`
or grepping the binary — both of which presuppose you already suspect an
env-var escape hatch exists. Meanwhile, the failure mode it fixes (silent
delete no-ops surfacing as `File exists` errors from apt/dpkg/`COPY`) gives
the user no clue that whiteouts are involved at all.

The new section documents the variable, gives the necessary background on why
deleting a file from a read-only lower layer needs a whiteout in the first
place, and includes the nested-podman-under-krun case as a worked example —
with the literal error strings, so the page is findable from the symptoms.

## Validation

- `man ./fuse-overlayfs.1` renders the section correctly (definition-list
  layout, code block indented consistently)
- `groff -Thtml -mandoc fuse-overlayfs.1` renders correctly
- markdown source uses pandoc-style definition lists to match the existing
  `fuse-overlayfs.1.md` conventions
